### PR TITLE
Fixed Rate bond example is incorrect.

### DIFF
--- a/examples/bonds.py
+++ b/examples/bonds.py
@@ -10,6 +10,7 @@ from quantlib.time.calendar import (
 )
 from quantlib.time.calendars.null_calendar import NullCalendar
 from quantlib.compounding import Continuous
+from quantlib.pricingengines.bond import DiscountingBondEngine
 from quantlib.time.date import Date, August, Period, Jul, Annual, Years
 from quantlib.time.daycounter import Actual365Fixed
 from quantlib.time.daycounters.actual_actual import ActualActual, ISMA
@@ -23,7 +24,7 @@ todays_date = Date(25, August, 2011)
 
 
 settings = Settings.instance()
-settings.evaluation_date =  todays_date
+settings.evaluation_date = todays_date
 
 calendar = TARGET()
 effective_date = Date(10, Jul, 2006)
@@ -68,8 +69,8 @@ flat_term_structure = FlatForward(
     compounding     = Continuous,
     frequency       = Annual)
 discounting_term_structure.link_to(flat_term_structure)
-
-bond.set_pricing_engine(discounting_term_structure)
+pricing_engine = DiscountingBondEngine(discounting_term_structure)
+bond.set_pricing_engine(pricing_engine)
 
 
 print 'Settlement date: ', bond.settlement_date()


### PR DESCRIPTION
When I run the example, I get this error:

```
Traceback (most recent call last):
  File "bonds.py", line 72, in <module>
    bond.set_pricing_engine(discounting_term_structure)
TypeError: Argument 'engine' has incorrect type (expected         quantlib.pricingengines.engine.PricingEngine, got     quantlib.termstructures.yields.yield_term_structure.YieldTermStructure)
```

I've changed it so that it runs correctly.
