### PR TITLE
Replace extern string declaration by import from libcpp.

### DIFF
--- a/quantlib/_currency.pxd
+++ b/quantlib/_currency.pxd
@@ -12,10 +12,8 @@
 
 include 'types.pxi'
 from libcpp cimport bool
+from libcpp.string cimport string
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()    
 
 cdef extern from 'ql/currency.hpp' namespace 'QuantLib':
 

--- a/quantlib/_index.pxd
+++ b/quantlib/_index.pxd
@@ -13,13 +13,11 @@
 include 'types.pxi'
 
 from libcpp cimport bool
+from libcpp.string cimport string
 
 from quantlib.time._calendar cimport Calendar
 from quantlib.time._date cimport Date
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/index.hpp' namespace 'QuantLib':
 

--- a/quantlib/indexes/_ibor_index.pxd
+++ b/quantlib/indexes/_ibor_index.pxd
@@ -12,6 +12,7 @@
 
 include '../types.pxi'
 from libcpp cimport bool
+from libcpp.string cimport string
 from quantlib.handle cimport shared_ptr, Handle
 
 from quantlib.time._date cimport Date
@@ -23,9 +24,6 @@ from quantlib._currency cimport Currency
 cimport quantlib.termstructures.yields._flat_forward as _ff
 from quantlib.indexes._interest_rate_index cimport InterestRateIndex
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()    
 
 cdef extern from 'ql/indexes/iborindex.hpp' namespace 'QuantLib':
 

--- a/quantlib/indexes/_interest_rate_index.pxd
+++ b/quantlib/indexes/_interest_rate_index.pxd
@@ -12,6 +12,7 @@
 
 include '../types.pxi'
 from libcpp cimport bool
+from libcpp.string cimport string
 
 from quantlib._index cimport Index
 from quantlib.time._date cimport Date
@@ -20,9 +21,6 @@ from quantlib.time._calendar cimport Calendar
 from quantlib.time._daycounter cimport DayCounter
 from quantlib._currency cimport Currency
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()    
 
 cdef extern from 'ql/indexes/interestrateindex.hpp' namespace 'QuantLib':
 

--- a/quantlib/indexes/_libor.pxd
+++ b/quantlib/indexes/_libor.pxd
@@ -11,6 +11,8 @@
 """
 
 include '../types.pxi'
+from libcpp.string cimport string
+
 from quantlib.handle cimport Handle
 cimport quantlib.termstructures._yield_term_structure as _yts
 from quantlib._currency cimport Currency
@@ -19,9 +21,6 @@ from quantlib.time._calendar cimport Calendar
 from quantlib.time._daycounter cimport DayCounter
 from quantlib.time._period cimport Period
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/indexes/ibor/libor.hpp' namespace 'QuantLib':
 

--- a/quantlib/indexes/_swap_index.pxd
+++ b/quantlib/indexes/_swap_index.pxd
@@ -12,6 +12,7 @@
 
 include '../types.pxi'
 from libcpp cimport bool
+from libcpp.string cimport string
 
 from quantlib.handle cimport shared_ptr
 from quantlib.indexes._interest_rate_index cimport InterestRateIndex
@@ -23,9 +24,6 @@ from quantlib.time._calendar cimport Calendar
 from quantlib.time._daycounter cimport DayCounter
 from quantlib._currency cimport Currency
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/indexes/swapindex.hpp' namespace 'QuantLib':
 

--- a/quantlib/indexes/ibor_index.pyx
+++ b/quantlib/indexes/ibor_index.pyx
@@ -1,5 +1,6 @@
 include '../types.pxi'
 from cython.operator cimport dereference as deref
+from libcpp.string cimport string
 
 from quantlib.handle cimport shared_ptr
 from quantlib.time.date cimport Period
@@ -15,9 +16,6 @@ from quantlib.indexes.euribor cimport Euribor
 
 from quantlib.market.conventions.swap import SwapData
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 from quantlib.indexes.interest_rate_index cimport InterestRateIndex
 

--- a/quantlib/indexes/interest_rate_index.pyx
+++ b/quantlib/indexes/interest_rate_index.pyx
@@ -10,6 +10,7 @@
 include '../types.pxi'
 from cython.operator cimport dereference as deref
 from libcpp cimport bool
+from libcpp.string cimport string
 
 from quantlib.index cimport Index
 from quantlib.handle cimport shared_ptr
@@ -27,9 +28,6 @@ cimport quantlib.time._period as _pe
 cimport quantlib.time._daycounter as _dc
 cimport quantlib.time._calendar as _ca
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef _iri.InterestRateIndex* get_iri(InterestRateIndex index):
     """ Utility function to extract a properly casted IRI pointer out of the

--- a/quantlib/instruments/_payoffs.pxd
+++ b/quantlib/instruments/_payoffs.pxd
@@ -1,10 +1,8 @@
 include '../types.pxi'
+from libcpp.string cimport string
 
 from quantlib.instruments._option cimport Type as OptionType
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/payoff.hpp' namespace 'QuantLib':
         

--- a/quantlib/time/_calendar.pxd
+++ b/quantlib/time/_calendar.pxd
@@ -1,14 +1,12 @@
 include '../types.pxi'
 
 from libcpp cimport bool
+from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 from _date cimport Date, Weekday
 from _period cimport Period, TimeUnit
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/time/businessdayconvention.hpp' namespace 'QuantLib':
     cdef enum BusinessDayConvention: 

--- a/quantlib/time/_daycounter.pxd
+++ b/quantlib/time/_daycounter.pxd
@@ -1,12 +1,9 @@
 include '../types.pxi'
 
 from libcpp cimport bool
+from libcpp.string cimport string
 from _date cimport Date
 from _calendar cimport Calendar
-
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 
 cdef extern from 'ql/time/daycounter.hpp' namespace 'QuantLib':

--- a/quantlib/time/_imm.pxd
+++ b/quantlib/time/_imm.pxd
@@ -13,11 +13,9 @@
 include '../types.pxi'
 
 from libcpp cimport bool
+from libcpp.string cimport string
 from _date cimport Date
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()    
 
 cdef extern from 'ql/time/imm.hpp' namespace "QuantLib::IMM":
 

--- a/quantlib/time/calendars/_jointcalendar.pxd
+++ b/quantlib/time/calendars/_jointcalendar.pxd
@@ -1,10 +1,8 @@
 include '../../types.pxi'
+from libcpp.string cimport string
 
 from quantlib.time._calendar cimport Calendar
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 cdef extern from 'ql/time/calendars/jointcalendar.hpp' namespace 'QuantLib':
 

--- a/quantlib/time/date.pyx
+++ b/quantlib/time/date.pyx
@@ -2,6 +2,7 @@ import datetime
 import re
 
 from cython.operator cimport dereference as deref
+from libcpp.string cimport string
 
 # cannot use date.pxd because of name clashing
 cimport _date
@@ -104,10 +105,6 @@ cdef public enum TimeUnit:
 
 _TU_DICT = {'D': Days, 'W': Weeks, 'M': Months, 'Y': Years}
 _STR_TU_DICT = {v:k for k, v in _TU_DICT.items()}
-
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 
 tenor_re = re.compile("([0-9]+)([DWMY]{1,1})")

--- a/quantlib/time/imm.pyx
+++ b/quantlib/time/imm.pyx
@@ -9,15 +9,13 @@
 
 from cython.operator cimport dereference as deref
 from libcpp cimport bool
+from libcpp.string cimport string
 cimport quantlib.time._date as _date
 cimport quantlib.time._imm as _imm
 
 from quantlib.time.date cimport Date
 from quantlib.time.date cimport date_from_qldate
 
-cdef extern from "string" namespace "std":
-    cdef cppclass string:
-        char* c_str()
 
 # IMM Months
 cdef public enum Month:


### PR DESCRIPTION
This PR replaces the explicit extern declaration of `std::string` by a cimport from `libcpp`. This should not affect the existing functionality.

When used with Cython 0.20 and up, this should fix #42.
