### PR TITLE
Fix typo in linker options in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def get_extra_link_args():
             int(item) for item in platform.mac_ver()[0].split('.')]
         if major == 10 and minor >= 9:
             # On Mac OS 10.9 we link against the libstdc++ library.
-            args = ['-stlib=libstdc++ -mmacosx-version-min=10.6']
+            args = ['-stdlib=libstdc++', '-mmacosx-version-min=10.6']
         else:
             args = []
     else:


### PR DESCRIPTION
This PR fixes a typo in the linking flags in setup.py for Mac OS 10.9.
