### PR TITLE
Fixes swap example and refactor of YieldTermStructure

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,10 +4,16 @@ PyQL CHANGELOG
 Pre 0.2
 -------
 
+ * YieldTermStructure refactor: internal storage of the term structures is now
+   done under the format of a Handle[YieldTermStructure] or a RelinkableHandle
+   if created with relinkable=True. Downstream methods are now all protected
+   when using empty handles.
+ * Swap example is now working.
  * Builds are finally usable on Windows 32 and 64 bit (two tests are failing due
    to numerical issues but the Singleton problem is fixed)
  * Python 3 support added (credits to Ed Schofield)
  * Drop support of Python 2.6
+ * Many small fixes (seel full commit logs)
 
 Release 0.1
 -----------

--- a/quantlib/handle.pxd
+++ b/quantlib/handle.pxd
@@ -20,7 +20,7 @@ cdef extern from 'ql/handle.hpp' namespace 'QuantLib':
     cdef cppclass RelinkableHandle[T](Handle):
         RelinkableHandle()
         RelinkableHandle(T*)
-        RelinkableHandle(shared_ptr[T]*)
+        RelinkableHandle(shared_ptr[T]&)
         void linkTo(shared_ptr[T]&)
         void linkTo(shared_ptr[T]&, bool registerAsObserver)
 

--- a/quantlib/handle.pxd
+++ b/quantlib/handle.pxd
@@ -16,6 +16,7 @@ cdef extern from 'ql/handle.hpp' namespace 'QuantLib':
         Handle(T*)
         Handle(shared_ptr[T]&)
         shared_ptr[T]& currentLink()
+        bool empty()
 
     cdef cppclass RelinkableHandle[T](Handle):
         RelinkableHandle()

--- a/quantlib/indexes/_euribor.pxd
+++ b/quantlib/indexes/_euribor.pxd
@@ -6,9 +6,10 @@ from quantlib.time._period cimport Period
 cdef extern from 'ql/indexes/ibor/euribor.hpp' namespace 'QuantLib':
 
     cdef cppclass Euribor(IborIndex):
-        Euribor()
+        Euribor() # added a fake constructor because of Cython
         Euribor(  Period& tenor,
                   Handle[_yts.YieldTermStructure]& h) except +
     
     cdef cppclass Euribor6M(Euribor):
+        Euribor6M()
         Euribor6M(Handle[_yts.YieldTermStructure]& yc)

--- a/quantlib/indexes/euribor.pyx
+++ b/quantlib/indexes/euribor.pyx
@@ -23,14 +23,7 @@ cdef class Euribor(IborIndex):
         YieldTermStructure ts):
 
         cdef Handle[_yts.YieldTermStructure] ts_handle
-        if ts.relinkable:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._relinkable_ptr.get().currentLink()
-            )
-        else:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._thisptr.get()
-            )
+        ts_handle = deref(ts._thisptr.get())
 
         self._thisptr = new shared_ptr[_in.Index](
         new _eu.Euribor(
@@ -45,14 +38,7 @@ cdef class Euribor6M(Euribor):
         if ts is None:
             self._thisptr = new shared_ptr[_in.Index](new _eu.Euribor6M())
         else:
-            if ts.relinkable:
-                ts_handle = Handle[_yts.YieldTermStructure](
-                    ts._relinkable_ptr.get() #.currentLink()
-                )
-            else:
-                ts_handle = Handle[_yts.YieldTermStructure](
-                    ts._thisptr.get()
-                )
+            ts_handle = deref(ts._thisptr.get())
 
             self._thisptr = new shared_ptr[_in.Index](
                 new _eu.Euribor6M(ts_handle)

--- a/quantlib/indexes/euribor.pyx
+++ b/quantlib/indexes/euribor.pyx
@@ -18,17 +18,18 @@ from quantlib.time.date cimport Period
 
 
 cdef class Euribor(IborIndex):
-    def __init__(self,
-        Period tenor,
-        YieldTermStructure ts):
+    def __init__(self, Period tenor, YieldTermStructure ts=None):
 
         cdef Handle[_yts.YieldTermStructure] ts_handle
-        ts_handle = deref(ts._thisptr.get())
+        if ts is None:
+            ts_handle = Handle[_yts.YieldTermStructure]()
+        else:
+            ts_handle = deref(ts._thisptr.get())
 
         self._thisptr = new shared_ptr[_in.Index](
-        new _eu.Euribor(
-            deref(tenor._thisptr.get()),
-            ts_handle)
+            new _eu.Euribor(
+                deref(tenor._thisptr.get()), ts_handle
+            )
         )
 
 cdef class Euribor6M(Euribor):
@@ -36,11 +37,11 @@ cdef class Euribor6M(Euribor):
 
         cdef Handle[_yts.YieldTermStructure] ts_handle
         if ts is None:
-            self._thisptr = new shared_ptr[_in.Index](new _eu.Euribor6M())
+            ts_handle = Handle[_yts.YieldTermStructure]()
         else:
             ts_handle = deref(ts._thisptr.get())
 
-            self._thisptr = new shared_ptr[_in.Index](
-                new _eu.Euribor6M(ts_handle)
-            )
+        self._thisptr = new shared_ptr[_in.Index](
+            new _eu.Euribor6M(ts_handle)
+        )
 

--- a/quantlib/indexes/euribor.pyx
+++ b/quantlib/indexes/euribor.pyx
@@ -21,7 +21,7 @@ cdef class Euribor(IborIndex):
     def __init__(self,
         Period tenor,
         YieldTermStructure ts):
-    
+
         cdef Handle[_yts.YieldTermStructure] ts_handle
         if ts.relinkable:
             ts_handle = Handle[_yts.YieldTermStructure](
@@ -35,21 +35,26 @@ cdef class Euribor(IborIndex):
         self._thisptr = new shared_ptr[_in.Index](
         new _eu.Euribor(
             deref(tenor._thisptr.get()),
-            ts_handle))
+            ts_handle)
+        )
 
 cdef class Euribor6M(Euribor):
-    def __init__(self, YieldTermStructure ts):
+    def __init__(self, YieldTermStructure ts=None):
 
         cdef Handle[_yts.YieldTermStructure] ts_handle
-        if ts.relinkable:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._relinkable_ptr.get().currentLink()
-            )
+        if ts is None:
+            self._thisptr = new shared_ptr[_in.Index](new _eu.Euribor6M())
         else:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._thisptr.get()
-            )
+            if ts.relinkable:
+                ts_handle = Handle[_yts.YieldTermStructure](
+                    ts._relinkable_ptr.get() #.currentLink()
+                )
+            else:
+                ts_handle = Handle[_yts.YieldTermStructure](
+                    ts._thisptr.get()
+                )
 
-        self._thisptr = new shared_ptr[_in.Index](
-            new _eu.Euribor6M(ts_handle))
+            self._thisptr = new shared_ptr[_in.Index](
+                new _eu.Euribor6M(ts_handle)
+            )
 

--- a/quantlib/indexes/ibor_index.pyx
+++ b/quantlib/indexes/ibor_index.pyx
@@ -41,13 +41,6 @@ cdef class IborIndex(InterestRateIndex):
         row = swap_params(market)
         row = row._replace(**kwargs)
 
-        # could use a dummy term structure here?
-        if term_structure is None:
-            term_structure = YieldTermStructure(relinkable=False)
-        # may not be needed at this stage...
-        # term_structure.link_to(FlatForward(settlement_date, 0.05,
-        #                                       Actual365Fixed()))
-
         if row.currency == 'EUR':
             from quantlib.indexes.euribor import Euribor
             ibor_index = Euribor(Period(row.floating_leg_period), term_structure)

--- a/quantlib/indexes/libor.pyx
+++ b/quantlib/indexes/libor.pyx
@@ -58,15 +58,8 @@ cdef class Libor(IborIndex):
         # convert the Python str to C++ string
         cdef string familyName_string = utf8_array_from_py_string(familyName)
 
-        cdef Handle[_yts.YieldTermStructure] ts_handle
-        if ts.relinkable:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._relinkable_ptr.get().currentLink()
-            )
-        else:
-            ts_handle = Handle[_yts.YieldTermStructure](
-                ts._thisptr.get()
-            )
+        cdef Handle[_yts.YieldTermStructure] ts_handle = \
+            deref(ts._thisptr.get())
 
         self._thisptr = new shared_ptr[_in.Index](
         new _libor.Libor(

--- a/quantlib/indexes/libor.pyx
+++ b/quantlib/indexes/libor.pyx
@@ -53,13 +53,16 @@ cdef class Libor(IborIndex):
         Currency currency,
         Calendar financial_center_calendar,
         DayCounter dayCounter,
-        YieldTermStructure ts):
+        YieldTermStructure ts=None):
 
         # convert the Python str to C++ string
         cdef string familyName_string = utf8_array_from_py_string(familyName)
 
-        cdef Handle[_yts.YieldTermStructure] ts_handle = \
-            deref(ts._thisptr.get())
+        cdef Handle[_yts.YieldTermStructure] ts_handle
+        if ts is not None:
+             ts_handle = deref(ts._thisptr.get())
+        else:
+            ts_handle = Handle[_yts.YieldTermStructure]()
 
         self._thisptr = new shared_ptr[_in.Index](
         new _libor.Libor(

--- a/quantlib/instruments/_vanillaswap.pxd
+++ b/quantlib/instruments/_vanillaswap.pxd
@@ -39,6 +39,16 @@ cdef extern from 'ql/instruments/vanillaswap.hpp' namespace 'QuantLib':
                     Schedule& floatSchedule,
                     shared_ptr[IborIndex] iborIndex,
                     Spread spread,
+                    DayCounter& floatingDayCount)
+
+        VanillaSwap(Type type,
+                    Real nominal,
+                    Schedule& fixedSchedule,
+                    Rate fixedRate,
+                    DayCounter& fixedDayCount,
+                    Schedule& floatSchedule,
+                    shared_ptr[IborIndex] iborIndex,
+                    Spread spread,
                     DayCounter& floatingDayCount,
                     BusinessDayConvention paymentConvention)
         

--- a/quantlib/instruments/swap.pyx
+++ b/quantlib/instruments/swap.pyx
@@ -138,21 +138,35 @@ cdef class VanillaSwap(Swap):
                      IborIndex ibor_index,
                      Spread spread,
                      DayCounter floating_daycount,
-                     BusinessDayConvention payment_convention):
+                     payment_convention=None):
 
         cdef QlSchedule* _fixed_schedule = <QlSchedule*>fixed_schedule._thisptr
         cdef QlSchedule* _float_schedule = <QlSchedule*>float_schedule._thisptr
 
 
-        self._thisptr = new shared_ptr[_instrument.Instrument](\
-            new _vanillaswap.VanillaSwap(<_vanillaswap.Type>type, nominal,
-                     deref(_fixed_schedule), fixed_rate,
-                     deref(fixed_daycount._thisptr),
-                     deref(_float_schedule),
-                     deref(<shared_ptr[_ib.IborIndex]*> ibor_index._thisptr),
-                     spread,
-                     deref(floating_daycount._thisptr),
-                     <BusinessDayConvention>payment_convention))
+        if payment_convention is None:
+             self._thisptr = new shared_ptr[_instrument.Instrument](\
+                new _vanillaswap.VanillaSwap(<_vanillaswap.Type>type, nominal,
+                         deref(_fixed_schedule), fixed_rate,
+                         deref(fixed_daycount._thisptr),
+                         deref(_float_schedule),
+                         deref(<shared_ptr[_ib.IborIndex]*> ibor_index._thisptr),
+                         spread,
+                         deref(floating_daycount._thisptr)
+                )
+            )
+        else:
+            self._thisptr = new shared_ptr[_instrument.Instrument](\
+                new _vanillaswap.VanillaSwap(<_vanillaswap.Type>type, nominal,
+                         deref(_fixed_schedule), fixed_rate,
+                         deref(fixed_daycount._thisptr),
+                         deref(_float_schedule),
+                         deref(<shared_ptr[_ib.IborIndex]*> ibor_index._thisptr),
+                         spread,
+                         deref(floating_daycount._thisptr),
+                         <BusinessDayConvention>payment_convention
+                )
+            )
 
     property fair_rate:
         def __get__(self):

--- a/quantlib/models/equity/heston_model.pyx
+++ b/quantlib/models/equity/heston_model.pyx
@@ -63,11 +63,10 @@ cdef class HestonModelHelper:
                 Handle[_qt.Quote](deref(volatility._thisptr))
 
         cdef Handle[_ffwd.YieldTermStructure] dividend_yield_handle = \
-            Handle[_ffwd.YieldTermStructure](deref(dividend_yield._thisptr))
+            deref(dividend_yield._thisptr.get())
 
         cdef Handle[_ffwd.YieldTermStructure]risk_free_rate_handle = \
-            Handle[_ffwd.YieldTermStructure](
-               deref(risk_free_rate._thisptr))
+            deref(risk_free_rate._thisptr.get())
 
         self._thisptr = new shared_ptr[_hm.HestonModelHelper](
             new _hm.HestonModelHelper(

--- a/quantlib/pricingengines/_swap.pxd
+++ b/quantlib/pricingengines/_swap.pxd
@@ -10,6 +10,12 @@ from _pricing_engine cimport PricingEngine
 cdef extern from 'ql/pricingengines/swap/discountingswapengine.hpp' namespace 'QuantLib':
 
     cdef cppclass DiscountingSwapEngine(PricingEngine):
+        DiscountingSwapEngine(Handle[YieldTermStructure]& discount_curve)
+        DiscountingSwapEngine(Handle[YieldTermStructure]& discount_curve,
+                              bool includeSettlementDateFlows)
+        DiscountingSwapEngine(Handle[YieldTermStructure]& discount_curve,
+                              bool includeSettlementDateFlows,
+                              Date& settlementDate)
         DiscountingSwapEngine(Handle[YieldTermStructure]& discount_curve,
                               bool includeSettlementDateFlows,
                               Date& settlementDate,

--- a/quantlib/pricingengines/bond.pyx
+++ b/quantlib/pricingengines/bond.pyx
@@ -21,16 +21,8 @@ cdef class DiscountingBondEngine(PricingEngine):
     def __init__(self, YieldTermStructure discount_curve):
         """
         """
-        cdef Handle[_yts.YieldTermStructure] yts_handle
-
-        if discount_curve.relinkable:
-            yts_handle = Handle[_yts.YieldTermStructure](
-                discount_curve._relinkable_ptr.get().currentLink()
-            )
-        else:
-            yts_handle = Handle[_yts.YieldTermStructure](
-                discount_curve._thisptr.get()
-            )
+        cdef Handle[_yts.YieldTermStructure] yts_handle = \
+            deref(discount_curve._thisptr.get())
 
         self._thisptr = new shared_ptr[_pe.PricingEngine](
             new _bond.DiscountingBondEngine(yts_handle)

--- a/quantlib/pricingengines/credit.pyx
+++ b/quantlib/pricingengines/credit.pyx
@@ -33,7 +33,7 @@ cdef class MidPointCdsEngine(PricingEngine):
             Handle[_dts.DefaultProbabilityTermStructure](deref(ts._thisptr))
 
         cdef Handle[_yts.YieldTermStructure] yts_handle = \
-            Handle[_yts.YieldTermStructure](deref(discount_curve._thisptr))
+            deref(discount_curve._thisptr.get())
 
         self._thisptr = new shared_ptr[_pe.PricingEngine](
             new _credit.MidPointCdsEngine(handle, recovery_rate, yts_handle)

--- a/quantlib/pricingengines/swap.pyx
+++ b/quantlib/pricingengines/swap.pyx
@@ -13,19 +13,28 @@ from quantlib.time.date cimport Date
 cdef class DiscountingSwapEngine(PricingEngine):
 
     def __init__(self, YieldTermStructure discount_curve,
-                 bool includeSettlementDateFlows,
-                 Date settlementDate,
-                 Date npvDate):
+                 includeSettlementDateFlows=None,
+                 Date settlementDate=None,
+                 Date npvDate=None):
 
         cdef Handle[_yts.YieldTermStructure] yts_handle = \
                 deref(discount_curve._thisptr.get())
-
-        self._thisptr = new shared_ptr[_pe.PricingEngine](
-            new _swap.DiscountingSwapEngine(
-                yts_handle,
-                includeSettlementDateFlows,
-                deref(settlementDate._thisptr.get()),
-                deref(npvDate._thisptr.get())
+        if includeSettlementDateFlows is None and settlementDate is None and \
+           npvDate is None:
+            self._thisptr = new shared_ptr[_pe.PricingEngine](
+                new _swap.DiscountingSwapEngine(yts_handle)
+            )            
+        elif includeSettlementDateFlows is not None and \
+             settlementDate is not None and \
+             npvDate is not None:
+            self._thisptr = new shared_ptr[_pe.PricingEngine](
+                new _swap.DiscountingSwapEngine(
+                    yts_handle,
+                    includeSettlementDateFlows,
+                    deref(settlementDate._thisptr.get()),
+                    deref(npvDate._thisptr.get())
+                )
             )
-        )
+        else:
+            raise NotImplementedError('Constructor not yet implemented')
 

--- a/quantlib/pricingengines/swap.pyx
+++ b/quantlib/pricingengines/swap.pyx
@@ -17,17 +17,8 @@ cdef class DiscountingSwapEngine(PricingEngine):
                  Date settlementDate,
                  Date npvDate):
 
-        cdef Handle[_yts.YieldTermStructure] yts_handle
-
-        if discount_curve.relinkable:
-            yts_handle = Handle[_yts.YieldTermStructure](
-                discount_curve._relinkable_ptr.get().currentLink()
-            )
-        else:
-            yts_handle = Handle[_yts.YieldTermStructure](
-                discount_curve._thisptr.get()
-            )
-
+        cdef Handle[_yts.YieldTermStructure] yts_handle = \
+                deref(discount_curve._thisptr.get())
 
         self._thisptr = new shared_ptr[_pe.PricingEngine](
             new _swap.DiscountingSwapEngine(

--- a/quantlib/processes/bates_process.pyx
+++ b/quantlib/processes/bates_process.pyx
@@ -57,13 +57,9 @@ cdef class BatesProcess(HestonProcess):
         #create handles
         cdef Handle[_qt.Quote] s0_handle = Handle[_qt.Quote](deref(s0._thisptr))
         cdef Handle[_ff.YieldTermStructure] dividend_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(dividend_ts._thisptr)
-                )
+                deref(dividend_ts._thisptr.get())
         cdef Handle[_ff.YieldTermStructure] risk_free_rate_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(risk_free_rate_ts._thisptr)
-                )
+                deref(risk_free_rate_ts._thisptr.get())
 
         self._thisptr = new shared_ptr[_hp.HestonProcess](
             new _hp.BatesProcess(

--- a/quantlib/processes/black_scholes_process.pyx
+++ b/quantlib/processes/black_scholes_process.pyx
@@ -28,9 +28,8 @@ cdef class BlackScholesProcess(GeneralizedBlackScholesProcess):
             deref(x0._thisptr)
         )
         cdef Handle[_ff.YieldTermStructure] risk_free_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(risk_free_ts._thisptr)
-                )
+                deref(risk_free_ts._thisptr.get())
+
         cdef Handle[_bvts.BlackVolTermStructure] black_vol_ts_handle = \
             Handle[_bvts.BlackVolTermStructure](
                 deref(black_vol_ts._thisptr)
@@ -56,13 +55,11 @@ cdef class BlackScholesMertonProcess(GeneralizedBlackScholesProcess):
             deref(x0._thisptr)
         )
         cdef Handle[_ff.YieldTermStructure] dividend_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(dividend_ts._thisptr)
-                )
+                deref(dividend_ts._thisptr.get())
+
         cdef Handle[_ff.YieldTermStructure] risk_free_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(risk_free_ts._thisptr)
-                )
+                deref(risk_free_ts._thisptr.get())
+
         cdef Handle[_bvts.BlackVolTermStructure] black_vol_ts_handle = \
             Handle[_bvts.BlackVolTermStructure](
                 deref(black_vol_ts._thisptr)

--- a/quantlib/processes/heston_process.pyx
+++ b/quantlib/processes/heston_process.pyx
@@ -55,13 +55,10 @@ cdef class HestonProcess:
         #create handles
         cdef Handle[_qt.Quote] s0_handle = Handle[_qt.Quote](deref(s0._thisptr))
         cdef Handle[_ff.YieldTermStructure] dividend_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(dividend_ts._thisptr)
-                )
+                deref(dividend_ts._thisptr.get())
+
         cdef Handle[_ff.YieldTermStructure] risk_free_rate_ts_handle = \
-                Handle[_ff.YieldTermStructure](
-                    deref(risk_free_rate_ts._thisptr)
-                )
+                deref(risk_free_rate_ts._thisptr.get())
 
         self._thisptr = new shared_ptr[_hp.HestonProcess](
             new _hp.HestonProcess(

--- a/quantlib/termstructures/credit/default_probability_helpers.pyx
+++ b/quantlib/termstructures/credit/default_probability_helpers.pyx
@@ -49,9 +49,7 @@ cdef class SpreadCdsHelper(CdsHelper):
         """
 
         cdef Handle[_yts.YieldTermStructure] yts = \
-                Handle[_yts.YieldTermStructure](
-                    deref(discount_curve._thisptr)
-                )
+            deref(discount_curve._thisptr.get())
 
 
         self._thisptr = new shared_ptr[_ci.CdsHelper](\

--- a/quantlib/termstructures/yields/_rate_helpers.pxd
+++ b/quantlib/termstructures/yields/_rate_helpers.pxd
@@ -72,6 +72,14 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
                        DayCounter& fixedDayCount,
                        shared_ptr[_ib.IborIndex]& iborIndex,
         )
+        SwapRateHelper(Handle[Quote]& rate,
+                       Period& tenor,
+                       Calendar& calendar,
+                       Frequency& fixedFrequency,
+                       BusinessDayConvention fixedConvention,
+                       DayCounter& fixedDayCount,
+                       shared_ptr[_ib.IborIndex]& iborIndex,
+        )
         SwapRateHelper(Rate rate,
                        Period& tenor,
                        Calendar& calendar,

--- a/quantlib/termstructures/yields/piecewise_yield_curve.pyx
+++ b/quantlib/termstructures/yields/piecewise_yield_curve.pyx
@@ -6,7 +6,7 @@ from libcpp.string cimport string
 cimport _piecewise_yield_curve as _pyc
 cimport _rate_helpers as _rh
 cimport _flat_forward as _ff
-from quantlib.handle cimport shared_ptr
+from quantlib.handle cimport shared_ptr, Handle
 from quantlib.util.compat cimport utf8_array_from_py_string
 
 from rate_helpers cimport RateHelper
@@ -69,14 +69,16 @@ cdef class PiecewiseYieldCurve(YieldTermStructure):
                 deref((<RateHelper> helper)._thisptr)
             )
 
-        self._thisptr = new shared_ptr[_ff.YieldTermStructure](
-            _pyc.term_structure_factory(
-                    trait_string,
-                    interpolator_string,
-                    deref(settlement_date._thisptr.get()),
-                    deref(instruments),
-                    deref(day_counter._thisptr),
-                    tolerance
+        self._thisptr = new shared_ptr[Handle[_ff.YieldTermStructure]](
+            new Handle[_ff.YieldTermStructure](
+                _pyc.term_structure_factory(
+                        trait_string,
+                        interpolator_string,
+                        deref(settlement_date._thisptr.get()),
+                        deref(instruments),
+                        deref(day_counter._thisptr),
+                        tolerance
+                )
             )
         )
 

--- a/quantlib/termstructures/yields/yield_term_structure.pxd
+++ b/quantlib/termstructures/yields/yield_term_structure.pxd
@@ -6,3 +6,5 @@ cdef class YieldTermStructure:
     cdef shared_ptr[Handle[_yts.YieldTermStructure]]* _thisptr
     cdef cbool relinkable
     cdef _yts.YieldTermStructure* _get_term_structure(self)
+    cdef _is_empty(self)
+    cdef _raise_if_empty(self)

--- a/quantlib/termstructures/yields/yield_term_structure.pxd
+++ b/quantlib/termstructures/yields/yield_term_structure.pxd
@@ -1,8 +1,8 @@
-cimport _flat_forward as _ff
+cimport quantlib.termstructures._yield_term_structure as _yts
 from libcpp cimport bool as cbool
-from quantlib.handle cimport shared_ptr, RelinkableHandle
+from quantlib.handle cimport shared_ptr, Handle
 
 cdef class YieldTermStructure:
-    cdef shared_ptr[_ff.YieldTermStructure]* _thisptr
-    cdef shared_ptr[RelinkableHandle[_ff.YieldTermStructure]]* _relinkable_ptr
+    cdef shared_ptr[Handle[_yts.YieldTermStructure]]* _thisptr
     cdef cbool relinkable
+    cdef _yts.YieldTermStructure* _get_term_structure(self)

--- a/quantlib/termstructures/yields/yield_term_structure.pyx
+++ b/quantlib/termstructures/yields/yield_term_structure.pyx
@@ -11,9 +11,10 @@ from quantlib.time.date cimport Date, date_from_qldate
 from quantlib.compounding import Continuous
 from quantlib.time.date import Annual
 
-cimport _flat_forward as ffwd
+cimport quantlib.termstructures._yield_term_structure as _yts
 cimport quantlib._quote as _qt
 cimport quantlib._interest_rate as _ir
+from quantlib.handle cimport Handle, shared_ptr, RelinkableHandle
 
 from quantlib.quotes cimport Quote
 from quantlib.interest_rate cimport InterestRate
@@ -26,34 +27,48 @@ cdef class YieldTermStructure:
     def __cinit__(self):
         self.relinkable = False
         self._thisptr = NULL
-        self._relinkable_ptr = NULL
 
     def __dealloc__(self):
         if self._thisptr is not NULL:
             del self._thisptr
-        if self._relinkable_ptr is not NULL:
-            del self._relinkable_ptr
 
     def __init__(self, relinkable=True):
         if relinkable:
             self.relinkable = True
             # Create a new RelinkableHandle to a YieldTermStructure within a
             # new shared_ptr
-            self._relinkable_ptr = new \
-                shared_ptr[ffwd.RelinkableHandle[ffwd.YieldTermStructure]](
-                    new ffwd.RelinkableHandle[ffwd.YieldTermStructure]()
+            self._thisptr = <shared_ptr[Handle[_yts.YieldTermStructure]]*> new \
+                shared_ptr[RelinkableHandle[_yts.YieldTermStructure]](
+                    new RelinkableHandle[_yts.YieldTermStructure]()
                 )
         else:
             # initialize an empty shared_ptr. ! Might be dangerous
-            self._thisptr = new shared_ptr[ffwd.YieldTermStructure]()
+            self._thisptr = new shared_ptr[Handle[_yts.YieldTermStructure]]()
 
     def link_to(self, YieldTermStructure structure):
+        cdef RelinkableHandle[_yts.YieldTermStructure]* rh
         if not self.relinkable:
             raise ValueError('Non relinkable term structure !')
         else:
-            self._relinkable_ptr.get().linkTo(deref(structure._thisptr))
+            rh = <RelinkableHandle[_yts.YieldTermStructure]*>self._thisptr.get()
+            rh.linkTo(
+                structure._thisptr.get().currentLink()
+            )
 
         return
+
+    cdef _yts.YieldTermStructure* _get_term_structure(self):
+        cdef _yts.YieldTermStructure* term_structure
+        cdef shared_ptr[_yts.YieldTermStructure] ts_ptr
+        ts_ptr = shared_ptr[_yts.YieldTermStructure](
+                self._thisptr.get().currentLink()
+        )
+        term_structure = ts_ptr.get()
+
+        if term_structure is NULL:
+            raise ValueError('Term structure not intialized')
+
+        return term_structure
 
     def zero_rate(
             self, Date date, DayCounter day_counter,
@@ -75,14 +90,7 @@ cdef class YieldTermStructure:
         extraplolate: bool, optional
             Default to False
         """
-        cdef ffwd.YieldTermStructure* term_structure
-        cdef shared_ptr[ffwd.YieldTermStructure] ts_ptr
-        if self.relinkable is True:
-            ts_ptr = shared_ptr[ffwd.YieldTermStructure](
-                self._relinkable_ptr.get().currentLink())
-            term_structure = ts_ptr.get()
-        else:
-            term_structure = self._thisptr.get()
+        cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
 
         cdef _ir.InterestRate ql_zero_rate = term_structure.zeroRate(
             deref(date._thisptr.get()), deref(day_counter._thisptr),
@@ -123,14 +131,7 @@ cdef class YieldTermStructure:
         extraplolate: bool, optional
             Default to False
         """
-        cdef ffwd.YieldTermStructure* term_structure
-        cdef shared_ptr[ffwd.YieldTermStructure] ts_ptr
-        if self.relinkable is True:
-            ts_ptr = shared_ptr[ffwd.YieldTermStructure](
-                self._relinkable_ptr.get().currentLink())
-            term_structure = ts_ptr.get()
-        else:
-            term_structure = self._thisptr.get()
+        cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
 
         cdef _ir.InterestRate ql_forward_rate = term_structure.forwardRate(
             deref(d1._thisptr.get()), deref(d2._thisptr.get()),
@@ -150,16 +151,7 @@ cdef class YieldTermStructure:
         return forward_rate
 
     def discount(self, value):
-        cdef ffwd.YieldTermStructure* term_structure
-        cdef shared_ptr[ffwd.YieldTermStructure] ts_ptr
-        if self.relinkable is True:
-            # retrieves the shared_ptr (currentLink()) then gets the
-            # term_structure (get())
-            ts_ptr = shared_ptr[ffwd.YieldTermStructure](
-                self._relinkable_ptr.get().currentLink())
-            term_structure = ts_ptr.get()
-        else:
-            term_structure = self._thisptr.get()
+        cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
 
         if isinstance(value, Date):
             discount_value = term_structure.discount(
@@ -176,10 +168,12 @@ cdef class YieldTermStructure:
 
     property reference_date:
         def __get__(self):
-            cdef ffwd.Date ref_date = self._thisptr.get().referenceDate()
+            cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
+            cdef _yts.Date ref_date = term_structure.referenceDate()
             return date_from_qldate(ref_date)
 
     property max_date:
         def __get__(self):
-            cdef ffwd.Date max_date = self._thisptr.get().maxDate()
+            cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
+            cdef _yts.Date max_date = term_structure.maxDate()
             return date_from_qldate(max_date)

--- a/quantlib/termstructures/yields/zero_curve.pyx
+++ b/quantlib/termstructures/yields/zero_curve.pyx
@@ -4,7 +4,7 @@ from cython.operator cimport dereference as deref
 from libcpp.vector cimport vector
 
 cimport _zero_curve as _zc
-from quantlib.handle cimport shared_ptr
+from quantlib.handle cimport shared_ptr, Handle
 from flat_forward cimport YieldTermStructure
 from quantlib.time.daycounter cimport DayCounter
 from quantlib.time.date cimport Date
@@ -25,10 +25,12 @@ cdef class ZeroCurve(YieldTermStructure):
             _yield_vector.push_back(rate)
 
         # create the curve
-        self._thisptr = new shared_ptr[_zc.YieldTermStructure](
-            new _zc.ZeroCurve(
-                deref(_date_vector),
-                deref(_yield_vector),
-                deref(daycounter._thisptr)
+        self._thisptr = new shared_ptr[Handle[_zc.YieldTermStructure]](
+            new Handle[_zc.YieldTermStructure](
+                new _zc.ZeroCurve(
+                    deref(_date_vector),
+                    deref(_yield_vector),
+                    deref(daycounter._thisptr)
+                )
             )
         )

--- a/quantlib/test/test_indexes.py
+++ b/quantlib/test/test_indexes.py
@@ -86,6 +86,12 @@ class TestEuribor(unittest.TestCase):
         self.assertEquals(index.name, 'Euribor6M Actual/360')
 
 
+    def test_empty_constructor(self):
+
+        euribor_6m_index = Euribor6M()
+        self.assertEquals(euribor_6m_index.name, 'Euribor6M Actual/360')
+
+
 class SwapIndexTestCase(unittest.TestCase):
 
     def test_create_swap_index(self):

--- a/quantlib/test/test_piecewise_yield_curve.py
+++ b/quantlib/test/test_piecewise_yield_curve.py
@@ -176,9 +176,10 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
 
             rate_helpers.append(helper)
 
-        liborIndex = Libor('USD Libor', Period(6, Months), settlement_days,
-                           USDCurrency(), calendar, Actual360(),
-                           YieldTermStructure(relinkable=False))
+        liborIndex = Libor(
+            'USD Libor', Period(6, Months), settlement_days, USDCurrency(),
+            calendar, Actual360()
+        )
 
         spread = SimpleQuote(0)
         fwdStart = Period(0, Days)
@@ -245,7 +246,7 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         # description of the float leg of the swap
         Swap_iborIndex = Libor(
             "USDLibor", Period(3, Months), settlement_days, USDCurrency(),
-            UnitedStates(), Actual360(), YieldTermStructure(relinkable=False)
+            UnitedStates(), Actual360()
         )
 
         SwapFamilyName = currency.name + "swapIndex"
@@ -257,9 +258,10 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         instruments = []
         for rate, tenor in zip(liborRates, liborRatesTenor):
             # Index description ___ creation of a Libor index
-            liborIndex =  Libor(LiborFamilyName, tenor, settlement_days,
-                                currency, calendar, Libor_dayCounter,
-                                YieldTermStructure(relinkable=False))
+            liborIndex =  Libor(
+                LiborFamilyName, tenor, settlement_days, currency, calendar,
+                Libor_dayCounter
+            )
             # Initialize rate helper
             # the DepositRateHelper link the recording rate with the Libor
             # index
@@ -269,9 +271,11 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
 
         for tenor, rate in zip(swapRatesTenor, swapRates):
             # swap description ___ creation of a swap index. The floating leg is described in the index 'Swap_iborIndex'
-            swapIndex = SwapIndex (SwapFamilyName, tenor, settlement_days, currency, calendar,
-                    Swap_fixedLegTenor, Swap_fixedLegConvention, Swap_fixedLegDayCounter,
-                    Swap_iborIndex)
+            swapIndex = SwapIndex (
+                SwapFamilyName, tenor, settlement_days, currency, calendar,
+                Swap_fixedLegTenor, Swap_fixedLegConvention,
+                Swap_fixedLegDayCounter, Swap_iborIndex
+            )
             # Initialize rate helper __ the SwapRateHelper links the swap index width his rate
             instruments.append(SwapRateHelper.from_index(rate,swapIndex))
 

--- a/quantlib/test/test_rate_helpers.py
+++ b/quantlib/test/test_rate_helpers.py
@@ -91,7 +91,7 @@ class RateHelpersTestCase(unittest.TestCase):
         family_name = currency.name + 'index'
         ibor_index =  Libor(
             "USDLibor", Period(3,Months), settlement_days, USDCurrency(),
-            UnitedStates(), Actual360(), YieldTermStructure(relinkable=False)
+            UnitedStates(), Actual360()
         )
 
         rate = 0.005681

--- a/quantlib/test/test_termstructures.py
+++ b/quantlib/test/test_termstructures.py
@@ -43,6 +43,13 @@ class SimpleQuoteTestCase(unittest.TestCase):
 
 class YieldTermStructureTestCase(unittest.TestCase):
 
+    def test_default_constructor(self):
+
+        term_structure = YieldTermStructure()
+
+        with self.assertRaises(ValueError):
+            term_structure.discount(Settings().evaluation_date)
+
     def test_relinkable_structures(self):
 
         discounting_term_structure = YieldTermStructure(relinkable=True)

--- a/quantlib/util/rates.py
+++ b/quantlib/util/rates.py
@@ -80,10 +80,10 @@ def make_rate_helper(label, rate, dt_obs, currency='USD'):
     end_of_month = True
 
     if((rate_type == 'SWAP') & (period == 'Y')):
-        liborIndex = Libor('USD Libor', Period(6, Months),
-                       settlement_days,
-                       USDCurrency(), calendar,
-                       Actual360(), YieldTermStructure(relinkable=False))
+        liborIndex = Libor(
+            'USD Libor', Period(6, Months), settlement_days,
+            USDCurrency(), calendar, Actual360()
+        )
         spread = SimpleQuote(0)
         fwdStart = Period(0, Days)
         helper = SwapRateHelper.from_tenor(rate,


### PR DESCRIPTION
The heart of this PR is the change of internal storage type of the YieldTermStructure. The changes was needed to properly support the QL RelinkableHandle's and Handle's used in the swap example. 

@jvkersch when you have time and will to look at this, I'm looking for a reviewer.

This PR fixes #76 