### PR TITLE
remove declaration of calendars that have been moved to

### DIFF
--- a/quantlib/time/calendar.pxd
+++ b/quantlib/time/calendar.pxd
@@ -9,12 +9,6 @@ cdef class Calendar:
 cdef class TARGET(Calendar):
     pass
 
-cdef class UnitedStates(Calendar):
-    pass
-
-cdef class UnitedKingdom(Calendar):
-    pass
-
 cdef class DateList:
     cdef vector[_date.Date]* _dates
     cdef size_t _pos


### PR DESCRIPTION
quantlib.time.calendars

Fixes #79 