### PR TITLE
remove deprecated Handle constructor

### DIFF
--- a/quantlib/handle.pxd
+++ b/quantlib/handle.pxd
@@ -13,7 +13,6 @@ cdef extern from 'boost/shared_ptr.hpp' namespace 'boost':
 cdef extern from 'ql/handle.hpp' namespace 'QuantLib':
     cdef cppclass Handle[T]:
         Handle()
-        Handle(T*)
         Handle(shared_ptr[T]&)
         shared_ptr[T]& currentLink()
         bool empty()
@@ -24,4 +23,3 @@ cdef extern from 'ql/handle.hpp' namespace 'QuantLib':
         RelinkableHandle(shared_ptr[T]&)
         void linkTo(shared_ptr[T]&)
         void linkTo(shared_ptr[T]&, bool registerAsObserver)
-

--- a/quantlib/termstructures/yields/flat_forward.pyx
+++ b/quantlib/termstructures/yields/flat_forward.pyx
@@ -109,6 +109,6 @@ cdef class FlatForward(YieldTermStructure):
             raise ValueError('Invalid constructor')
 
         self._thisptr = new shared_ptr[Handle[ffwd.YieldTermStructure]](
-                new Handle[ffwd.YieldTermStructure](_forward)
+             new Handle[ffwd.YieldTermStructure](shared_ptr[ffwd.YieldTermStructure](_forward))
         )
 

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -40,10 +40,8 @@ cdef class RateHelper:
 
     property quote:
         def __get__(self):
-            cdef Handle[_qt.Quote] quote_handle = self._thisptr.get().quote()
-            cdef shared_ptr[_qt.Quote] quote_ptr = shared_ptr[_qt.Quote](quote_handle.currentLink())
-            value = quote_ptr.get().value()
-            return value
+            cdef shared_ptr[_qt.Quote] quote_ptr = shared_ptr[_qt.Quote](self._thisptr.get().quote().currentLink())
+            return quote_ptr.get().value()
 
     property implied_quote:
         def __get__(self):
@@ -62,10 +60,8 @@ cdef class RelativeDateRateHelper:
 
     property quote:
         def __get__(self):
-            cdef Handle[_qt.Quote] quote_handle = self._thisptr.get().quote()
-            cdef shared_ptr[_qt.Quote] quote_ptr = shared_ptr[_qt.Quote](quote_handle.currentLink())
-            value = quote_ptr.get().value()
-            return value
+            cdef shared_ptr[_qt.Quote] quote_ptr = shared_ptr[_qt.Quote](self._thisptr.get().quote().currentLink())
+            return quote_ptr.get().value()
 
     property implied_quote:
         def __get__(self):
@@ -175,7 +171,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
     @classmethod
     def from_index(cls, double rate, SwapIndex index):
 
-        cdef Handle[_qt.Quote] spread_handle = Handle[_qt.Quote](new _qt.SimpleQuote(0))
+        cdef Handle[_qt.Quote] spread_handle = Handle[_qt.Quote](shared_ptr[_qt.Quote](new _qt.SimpleQuote(0)))
         cdef Period p = Period(2, Days)
 
 

--- a/quantlib/termstructures/yields/zero_curve.pyx
+++ b/quantlib/termstructures/yields/zero_curve.pyx
@@ -26,11 +26,10 @@ cdef class ZeroCurve(YieldTermStructure):
 
         # create the curve
         self._thisptr = new shared_ptr[Handle[_zc.YieldTermStructure]](
-            new Handle[_zc.YieldTermStructure](
+            new Handle[_zc.YieldTermStructure](shared_ptr[_zc.YieldTermStructure](
                 new _zc.ZeroCurve(
                     deref(_date_vector),
                     deref(_yield_vector),
-                    deref(daycounter._thisptr)
-                )
+                    deref(daycounter._thisptr)))
             )
         )


### PR DESCRIPTION
It has already been removed in quantlib as of commit lballabio/quantlib@71e0bb1
