### PR TITLE
Rate Helpers - SwapRateHelper/DepositRateHelper to take in SimpleQuote

### DIFF
--- a/quantlib/termstructures/yields/_rate_helpers.pxd
+++ b/quantlib/termstructures/yields/_rate_helpers.pxd
@@ -64,7 +64,7 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
 
 
     cdef cppclass SwapRateHelper(RelativeDateRateHelper):
-        SwapRateHelper(Rate rate,
+        SwapRateHelper(Handle[Quote]& rate,
                        Period& tenor,
                        Calendar& calendar,
                        Frequency& fixedFrequency,
@@ -79,18 +79,10 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
                        BusinessDayConvention fixedConvention,
                        DayCounter& fixedDayCount,
                        shared_ptr[_ib.IborIndex]& iborIndex,
-        )
-        SwapRateHelper(Rate rate,
-                       Period& tenor,
-                       Calendar& calendar,
-                       Frequency& fixedFrequency,
-                       BusinessDayConvention fixedConvention,
-                       DayCounter& fixedDayCount,
-                       shared_ptr[_ib.IborIndex]& iborIndex,
                        Handle[Quote]& spread,
                        Period& fwdStart
         )
-        SwapRateHelper(Rate rate,
+        SwapRateHelper(Handle[Quote]& rate,
                        shared_ptr[SwapIndex]& swapIndex,
                        #Handle[Quote]& spread, # = Handle<Quote>(),
                        #Period& fwdStart, # = 0*Days,

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -69,25 +69,25 @@ cdef class RelativeDateRateHelper:
 
 
 cdef class DepositRateHelper(RateHelper):
-    """Rate helper for bootstrapping over deposit rates. """
+    """Rate helper for bootstrapping over deposit rates. [uses SimpleQuotes] update 05/14/2015"""
 
-    def __init__(self, Rate quote, Period tenor=None, Natural fixing_days=0,
+    def __init__(self, Quote quote, Period tenor=None, Natural fixing_days=0,
         Calendar calendar=None, int convention=ModifiedFollowing,
         end_of_month=True, DayCounter deposit_day_counter=None,
-        IborIndex index=None
-    ):
-
+        IborIndex index=None):
+        cdef Handle[_qt.Quote] rate_handle = Handle[_qt.Quote](deref(quote._thisptr))
+        
         if index is not None:
             self._thisptr = new shared_ptr[_rh.RateHelper](
                 new _rh.DepositRateHelper(
-                    quote,
+                    rate_handle,
                     deref(<shared_ptr[_ib.IborIndex]*> index._thisptr)
                 )
             )
         else:
             self._thisptr = new shared_ptr[_rh.RateHelper](
                 new _rh.DepositRateHelper(
-                    quote,
+                    rate_handle,
                     deref(tenor._thisptr.get()),
                     <int>fixing_days,
                     deref(calendar._thisptr),
@@ -96,9 +96,9 @@ cdef class DepositRateHelper(RateHelper):
                     deref(deposit_day_counter._thisptr)
                 )
             )
-
 cdef class SwapRateHelper(RelativeDateRateHelper):
-
+    """Rate helper for bootstrapping over swap rates, use from_tenor or from_index function, 
+    from_tenor uses SimpleQuote() instead of double""" 
     def __init__(self, from_classmethod=False):
         # Creating a SwaprRateHelper without using a class method means the
         # shared_ptr won't be initialized properly and break any subsequent calls
@@ -116,13 +116,14 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         self._thisptr = ptr
 
     @classmethod
-    def from_tenor(cls, rate, Period tenor,
+    def from_tenor(cls, Quote rate, Period tenor,
         Calendar calendar, Frequency fixedFrequency,
         BusinessDayConvention fixedConvention, DayCounter fixedDayCount,
         IborIndex iborIndex, Quote spread=None, Period fwdStart=None):
-
+        
+        cdef Handle[_qt.Quote] rate_handle = Handle[_qt.Quote](deref(rate._thisptr))
         cdef Handle[_qt.Quote] spread_handle
-        cdef Handle[_qt.Quote] _rate
+#        cdef Handle[_qt.Quote] _rate    #from merge w/ master, might not need this any longer?
 
         cdef _qt.SimpleQuote* qt 
         cdef shared_ptr[_qt.Quote] ptr
@@ -132,7 +133,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         elif isinstance(rate, SimpleQuote):
             ptr = deref((<SimpleQuote>rate)._thisptr)
 
-        _rate = Handle[_qt.Quote](ptr)
+#        _rate = Handle[_qt.Quote](ptr) #from merge w/ master, might not need this any longer?
 
 
         cdef SwapRateHelper instance = cls(from_classmethod=True)
@@ -140,7 +141,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         if spread is None:
             instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
                 new _rh.SwapRateHelper(
-                    _rate,
+                    rate_handle,
                     deref(tenor._thisptr.get()),
                     deref(calendar._thisptr),
                     <Frequency> fixedFrequency,
@@ -154,7 +155,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
 
             instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
                 new _rh.SwapRateHelper(
-                    rate,
+                    rate_handle,
                     deref(tenor._thisptr.get()),
                     deref(calendar._thisptr),
                     <Frequency> fixedFrequency,
@@ -169,8 +170,9 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         return instance
 
     @classmethod
-    def from_index(cls, double rate, SwapIndex index):
+    def from_index(cls, Quote rate, SwapIndex index):
 
+        cdef Handle[_qt.Quote] rate_handle = Handle[_qt.Quote](deref(rate._thisptr))
         cdef Handle[_qt.Quote] spread_handle = Handle[_qt.Quote](shared_ptr[_qt.Quote](new _qt.SimpleQuote(0)))
         cdef Period p = Period(2, Days)
 
@@ -179,7 +181,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
 
         instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
             new _rh.SwapRateHelper(
-                rate,
+                rate_handle,
                 deref(<shared_ptr[_si.SwapIndex]*>index._thisptr),
                 #spread_handle,
                 #deref(p._thisptr.get()))

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -69,7 +69,7 @@ cdef class RelativeDateRateHelper:
 
 
 cdef class DepositRateHelper(RateHelper):
-    """Rate helper for bootstrapping over deposit rates. [uses SimpleQuotes] update 05/14/2015"""
+    """Rate helper for bootstrapping over deposit rates."""
 
     def __init__(self, Quote quote, Period tenor=None, Natural fixing_days=0,
         Calendar calendar=None, int convention=ModifiedFollowing,
@@ -97,8 +97,7 @@ cdef class DepositRateHelper(RateHelper):
                 )
             )
 cdef class SwapRateHelper(RelativeDateRateHelper):
-    """Rate helper for bootstrapping over swap rates, use from_tenor or from_index function, 
-    from_tenor uses SimpleQuote() instead of double""" 
+    """Rate helper for bootstrapping over swap rates, use from_tenor or from_index function""" 
     def __init__(self, from_classmethod=False):
         # Creating a SwaprRateHelper without using a class method means the
         # shared_ptr won't be initialized properly and break any subsequent calls
@@ -123,7 +122,6 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         
         cdef Handle[_qt.Quote] rate_handle = Handle[_qt.Quote](deref(rate._thisptr))
         cdef Handle[_qt.Quote] spread_handle
-#        cdef Handle[_qt.Quote] _rate    #from merge w/ master, might not need this any longer?
 
         cdef _qt.SimpleQuote* qt 
         cdef shared_ptr[_qt.Quote] ptr
@@ -132,9 +130,6 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
             ptr = deref(new shared_ptr[_qt.Quote](qt))
         elif isinstance(rate, SimpleQuote):
             ptr = deref((<SimpleQuote>rate)._thisptr)
-
-#        _rate = Handle[_qt.Quote](ptr) #from merge w/ master, might not need this any longer?
-
 
         cdef SwapRateHelper instance = cls(from_classmethod=True)
 

--- a/quantlib/test/test_market.py
+++ b/quantlib/test/test_market.py
@@ -1,9 +1,8 @@
 from .unittest_tools import unittest
-
 from quantlib.compounding import Simple
 from quantlib.time.api import Date, Actual360
 from quantlib.market.market import libor_market, IborMarket
-
+from quantlib.quotes import SimpleQuote
 
 class MarketTestCase(unittest.TestCase):
 
@@ -20,17 +19,17 @@ class MarketTestCase(unittest.TestCase):
         # add quotes
         eval_date = Date(20, 9, 2004)
 
-        quotes = [('DEP', '1W', 0.0382),
-                  ('DEP', '1M', 0.0372),
-                  ('DEP', '3M', 0.0363),
-                  ('DEP', '6M', 0.0353),
-                  ('DEP', '9M', 0.0348),
-                  ('DEP', '1Y', 0.0345),
-                  ('SWAP', '2Y', 0.037125),
-                  ('SWAP', '3Y', 0.0398),
-                  ('SWAP', '5Y', 0.0443),
-                  ('SWAP', '10Y', 0.05165),
-                  ('SWAP', '15Y', 0.055175)]
+        quotes = [('DEP', '1W', SimpleQuote(0.0382)),
+                  ('DEP', '1M', SimpleQuote(0.0372)),
+                  ('DEP', '3M', SimpleQuote(0.0363)),
+                  ('DEP', '6M', SimpleQuote(0.0353)),
+                  ('DEP', '9M', SimpleQuote(0.0348)),
+                  ('DEP', '1Y', SimpleQuote(0.0345)),
+                  ('SWAP', '2Y', SimpleQuote(0.037125)),
+                  ('SWAP', '3Y', SimpleQuote(0.0398)),
+                  ('SWAP', '5Y', SimpleQuote(0.0443)),
+                  ('SWAP', '10Y', SimpleQuote(0.05165)),
+                  ('SWAP', '15Y', SimpleQuote(0.055175))]
 
         m.set_quotes(eval_date, quotes)
 
@@ -147,12 +146,12 @@ class MarketTestCase(unittest.TestCase):
         m = libor_market('USD(NY)')
         eval_date = Date(20, 9, 2004)
 
-        quotes = [('DEP', '1W', 0.0382),
-                  ('DEP', '1M', 0.0372),
-                  ('DEP', '3M', 0.0363),
-                  ('DEP', '6M', 0.0353),
-                  ('DEP', '9M', 0.0348),
-                  ('DEP', '1Y', 0.0345)]
+        quotes = [('DEP', '1W', SimpleQuote(0.0382)),
+                  ('DEP', '1M', SimpleQuote(0.0372)),
+                  ('DEP', '3M', SimpleQuote(0.0363)),
+                  ('DEP', '6M', SimpleQuote(0.0353)),
+                  ('DEP', '9M', SimpleQuote(0.0348)),
+                  ('DEP', '1Y', SimpleQuote(0.0345))]
 
         m.set_quotes(eval_date, quotes)
         ts = m.bootstrap_term_structure()

--- a/quantlib/test/test_mlab.py
+++ b/quantlib/test/test_mlab.py
@@ -12,6 +12,7 @@ import quantlib.reference.data_structures as ds
 from quantlib.termstructures.yields.api import PiecewiseYieldCurve
 from quantlib.time.api import ActualActual, ISDA
 from quantlib.util.converter import pydate_to_qldate
+from quantlib.quotes import SimpleQuote
 
 
 class MLabTestCase(unittest.TestCase):
@@ -71,16 +72,16 @@ class MLabTestCase(unittest.TestCase):
 
     def test_yield(self):
 
-        rates_data = [('Libor1M', .01),
-                  ('Libor3M', .015),
-                  ('Libor6M', .017),
-                  ('Swap1Y', .02),
-                  ('Swap2Y', .03),
-                  ('Swap3Y', .04),
-                  ('Swap5Y', .05),
-                  ('Swap7Y', .06),
-                  ('Swap10Y', .07),
-                  ('Swap20Y', .08)]
+        rates_data = [('Libor1M',SimpleQuote(.01)),
+                  ('Libor3M', SimpleQuote(.015)),
+                  ('Libor6M', SimpleQuote(.017)),
+                  ('Swap1Y', SimpleQuote(.02)),
+                  ('Swap2Y', SimpleQuote(.03)),
+                  ('Swap3Y', SimpleQuote(.04)),
+                  ('Swap5Y', SimpleQuote(.05)),
+                  ('Swap7Y', SimpleQuote(.06)),
+                  ('Swap10Y', SimpleQuote(.07)),
+                  ('Swap20Y', SimpleQuote(.08))]
 
         settlement_date = pydate_to_qldate('01-Dec-2013')
         rate_helpers = []
@@ -188,9 +189,9 @@ class MLabTestCase(unittest.TestCase):
                    'Swap10Y',
                    'Swap20Y',
                    'Swap30Y']
-        yields = [.01, .015, .02, .03, .04,
-              .05, .06, .07, .08, .09,
-              .1]
+        yields = [SimpleQuote(.01), SimpleQuote(.015), SimpleQuote(.02), SimpleQuote(.03), SimpleQuote(.04),
+              SimpleQuote(.05), SimpleQuote(.06), SimpleQuote(.07), SimpleQuote(.08), SimpleQuote(.09),
+              SimpleQuote(.1)]
 
         pricing_date = '01-dec-2013'
         dt, rates = zbt_libor_yield(instruments, yields, pricing_date,
@@ -198,3 +199,6 @@ class MLabTestCase(unittest.TestCase):
                     maturity_dates=None)
 
         self.assertAlmostEqual(rates[0], .01, 3)
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/quantlib/test/test_piecewise_yield_curve.py
+++ b/quantlib/test/test_piecewise_yield_curve.py
@@ -44,7 +44,7 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         # must be a business day
         settlement_date = calendar.adjust(settlement_date);
 
-        quotes = [0.0096, 0.0145, 0.0194]
+        quotes = [SimpleQuote(0.0096), SimpleQuote(0.0145), SimpleQuote(0.0194)]
         tenors =  [3, 6, 12]
 
         rate_helpers = []
@@ -98,8 +98,9 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         settlement_date = Date(18, September, 2008)
         # must be a business day
         settlement_date = calendar.adjust(settlement_date);
+        
+        quotes = [SimpleQuote(0.0096), SimpleQuote(0.0145), SimpleQuote(0.0194)]
 
-        quotes = [0.0096, 0.0145, 0.0194]
         tenors =  [3, 6, 12]
 
         rate_helpers = []
@@ -170,7 +171,8 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         for m, period, rate in depositData:
             tenor = Period(m, Months)
 
-            helper = DepositRateHelper(rate/100, tenor, settlement_days,
+
+            helper = DepositRateHelper(SimpleQuote(rate/100), tenor, settlement_days,
                      calendar, ModifiedFollowing, end_of_month,
                      Actual360())
 
@@ -187,7 +189,7 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
         for m, period, rate in swapData:
 
             helper = SwapRateHelper.from_tenor(
-                rate/100, Period(m, Years), calendar, Annual, Unadjusted, Thirty360(), liborIndex,
+                SimpleQuote(rate/100), Period(m, Years), calendar, Annual, Unadjusted, Thirty360(), liborIndex,
                 spread, fwdStart
             )
 
@@ -230,14 +232,14 @@ class PiecewiseYieldCurveTestCase(unittest.TestCase):
             todays_date, period=Period(settlement_days, Days)
         )
 
-        liborRates = [ 0.002763, 0.004082, 0.005601, 0.006390, 0.007125, 0.007928, 0.009446,
-            0.01110]
+        liborRates = [ SimpleQuote(0.002763), SimpleQuote(0.004082), SimpleQuote(0.005601), SimpleQuote(0.006390), SimpleQuote(0.007125), 
+            SimpleQuote(0.007928), SimpleQuote(0.009446), SimpleQuote(0.01110)]
         liborRatesTenor = [Period(tenor, Months) for tenor in [1,2,3,4,5,6,9,12]]
         Libor_dayCounter = Actual360();
 
 
-        swapRates = [0.005681, 0.006970, 0.009310, 0.012010, 0.014628, 0.016881, 0.018745,
-                 0.020260, 0.021545]
+        swapRates = [SimpleQuote(0.005681), SimpleQuote(0.006970), SimpleQuote(0.009310), SimpleQuote(0.012010), SimpleQuote(0.014628),
+                 SimpleQuote(0.016881), SimpleQuote(0.018745), SimpleQuote(0.020260), SimpleQuote(0.021545)]
         swapRatesTenor = [Period(i, Years) for i in range(2, 11)]
         # description of the fixed leg of the swap
         Swap_fixedLegTenor = Period(12, Months)      # INPUT

--- a/quantlib/test/test_rate_helpers.py
+++ b/quantlib/test/test_rate_helpers.py
@@ -17,7 +17,7 @@ class RateHelpersTestCase(unittest.TestCase):
 
     def test_create_deposit_rate_helper(self):
 
-        quote = 0.0096
+        quote = SimpleQuote(0.0096)
         tenor = Period(3, Months)
         fixing_days = 3
         calendar =  TARGET()
@@ -32,7 +32,7 @@ class RateHelpersTestCase(unittest.TestCase):
         )
 
         self.assertIsNotNone(helper)
-        self.assertEquals(quote, helper.quote)
+        self.assertEquals(quote.value, helper.quote)
 
 
     def test_create_fra_rate_helper(self):
@@ -94,7 +94,7 @@ class RateHelpersTestCase(unittest.TestCase):
             UnitedStates(), Actual360()
         )
 
-        rate = 0.005681
+        rate = SimpleQuote(0.005681)
         tenor = Period(1, Years)
 
         index = SwapIndex (
@@ -110,10 +110,10 @@ class RateHelpersTestCase(unittest.TestCase):
         #)
 
         self.assertIsNotNone(helper)
-        self.assertAlmostEquals(rate, helper.quote)
+        self.assertAlmostEquals(rate.value, helper.quote)
 
         with self.assertRaises(RuntimeError):
-            self.assertAlmostEquals(rate, helper.implied_quote)
+            self.assertAlmostEquals(rate.value, helper.implied_quote)
 
 if __name__ == '__main__':
     unittest.main()

--- a/quantlib/test/test_swap.py
+++ b/quantlib/test/test_swap.py
@@ -15,7 +15,7 @@ from quantlib.time.api import (
     Schedule, Forward
 )
 from quantlib.util.converter import pydate_to_qldate
-
+from quantlib.quotes import SimpleQuote
 
 
 class TestQuantLibSwap(unittest.TestCase):
@@ -120,17 +120,17 @@ class TestQuantLibSwap(unittest.TestCase):
 
         m = libor_market('USD(NY)')
 
-        quotes = [('DEP', '1W', 0.0382),
-                  ('DEP', '1M', 0.0372),
-                  ('DEP', '3M', 0.0363),
-                  ('DEP', '6M', 0.0353),
-                  ('DEP', '9M', 0.0348),
-                  ('DEP', '1Y', 0.0345),
-                  ('SWAP', '2Y', 0.037125),
-                  ('SWAP', '3Y', 0.0398),
-                  ('SWAP', '5Y', 0.0443),
-                  ('SWAP', '10Y', 0.05165),
-                  ('SWAP', '15Y', 0.055175)]
+        quotes = [('DEP', '1W', SimpleQuote(0.0382)),
+                  ('DEP', '1M', SimpleQuote(0.0372)),
+                  ('DEP', '3M', SimpleQuote(0.0363)),
+                  ('DEP', '6M', SimpleQuote(0.0353)),
+                  ('DEP', '9M', SimpleQuote(0.0348)),
+                  ('DEP', '1Y', SimpleQuote(0.0345)),
+                  ('SWAP', '2Y', SimpleQuote(0.037125)),
+                  ('SWAP', '3Y', SimpleQuote(0.0398)),
+                  ('SWAP', '5Y', SimpleQuote(0.0443)),
+                  ('SWAP', '10Y', SimpleQuote(0.05165)),
+                  ('SWAP', '15Y', SimpleQuote(0.055175))]
 
         m.set_quotes(eval_date, quotes)
 


### PR DESCRIPTION
All rate helpers have been configured to take in SimpleQuotes instead of doubles. This will help with consistency (FRARateHelper, FuturesRateHelper both take in SimpleQuote) and is necessary when passing instruments to bucketAnalysis (SimpleQuotes from term structures need to be passed in), which will be added later on.  