### PR TITLE
setup.py/packaging improvements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.dll

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 global-include *.dll
+include quantlib/preload_dlls.txt

--- a/quantlib/__init__.py
+++ b/quantlib/__init__.py
@@ -1,6 +1,15 @@
 import sys
 import os
 
-# add the root folder to PATH so the quantlib dll can be found
+# preload the QuantLib dlls that are included in the package
 if sys.platform == 'win32':
-    os.environ["PATH"] = os.path.abspath(os.path.dirname(__file__)) + ";" + os.environ["PATH"]
+    try:
+        import pkg_resources
+        import ctypes
+        preload_dlls = pkg_resources.resource_string(__name__, "preload_dlls.txt").decode()
+        for dll in preload_dlls.splitlines():
+            ctypes.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), dll.strip()))
+    except (ImportError, IOError):
+        # If the resource couldn't be found or if pkg_resources doesn't exist set the PATH
+        # to include this folder.
+        os.environ["PATH"] = os.path.abspath(os.path.dirname(__file__)) + ";" + os.environ["PATH"]

--- a/quantlib/__init__.py
+++ b/quantlib/__init__.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+# add the root folder to PATH so the quantlib dll can be found
+if sys.platform == 'win32':
+    os.environ["PATH"] = os.path.abspath(os.path.dirname(__file__)) + ";" + os.environ["PATH"]

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,13 @@ import sys
 from Cython.Distutils import build_ext
 from Cython.Build import cythonize
 
+if sys.platform == 'win32':
+    VC_INCLUDE_REDIST = False  # Set to True to include C runtime dlls in distribution.
+    from distutils import msvc9compiler
+    from platform import architecture
+    VC_VERSION = msvc9compiler.VERSION
+    ARCH = "x64" if architecture()[0] == "64bit" else "x86"
+
 try:
     import numpy
     HAS_NUMPY = True
@@ -43,8 +50,9 @@ if sys.platform == 'darwin':
 elif sys.platform == 'win32':
     # With MSVC2008, the library is called QuantLib.lib but with MSVC2010, the
     # naming is QuantLib-vc100-mt
-    if sys.version_info >= (3, 0):
-        QL_LIBRARY = 'QuantLib-vc100-mt'
+    if VC_VERSION >= 10.0:
+        QL_LIBRARY = 'QuantLib-vc%d0-%s-mt' % (VC_VERSION, ARCH)
+
     INCLUDE_DIRS = [
         r'c:\dev\QuantLib-1.4',  # QuantLib headers
         r'c:\dev\boost_1_56_0',  # Boost headers
@@ -94,7 +102,7 @@ def get_extra_compile_args():
 
 def get_extra_link_args():
     if sys.platform == 'win32':
-        args = ['/subsystem:windows', '/machine:I386']
+        args = ['/subsystem:windows', '/machine:%s' % ARCH]
         if DEBUG:
             args.append('/DEBUG')
     elif sys.platform == 'darwin':
@@ -235,14 +243,59 @@ def collect_extensions():
 
     return extensions
 
+
+class pyql_build_ext(build_ext):
+    """
+    Custom build command for quantlib that on Windows copies the quantlib dll
+    and optionally c runtime dlls to the quantlib package.
+    """
+
+    def run(self):
+        build_ext.run(self)
+
+        # Find the quantlib dll and copy it to the built package
+        if sys.platform == "win32":
+            dlls = []
+            for libdir in LIBRARY_DIRS:
+                if os.path.exists(os.path.join(libdir, QL_LIBRARY + ".dll")):
+                    dlls.append(os.path.join(libdir, QL_LIBRARY + ".dll"))
+                    break
+            else:
+                raise AssertionError("%s.dll not found" % QL_LIBRARY)
+
+            # Find the visual studio runtime redist dlls
+            if VC_INCLUDE_REDIST:
+                plat_name = msvc9compiler.get_platform()
+                plat_spec = msvc9compiler.PLAT_TO_VCVARS[plat_name]
+
+                # look for the compiler executable
+                vc_env = msvc9compiler.query_vcvarsall(VC_VERSION, plat_spec)
+                for path in vc_env['path'].split(os.pathsep):
+                    if os.path.exists(os.path.join(path, "cl.exe")):
+                        crt_dir = "Microsoft.VC%d0.CRT" % VC_VERSION
+                        redist_dir = os.path.join(path, "..", ".redist", ARCH, crt_dir)
+                        if not os.path.exists(redist_dir):
+                            redist_dir = os.path.join(path, "..", "..", "redist", ARCH, crt_dir)
+                        break
+                else:
+                    raise RuntimeError("Can't find cl.exe")
+
+                assert os.path.exists(redist_dir), "Can't find CRT redist dlls '%s'" % redist_dir
+                dlls.extend(glob.glob(os.path.join(redist_dir, "*.*")))
+
+            for dll in dlls:
+                self.copy_file(dll, os.path.join(self.build_lib, "quantlib", os.path.basename(dll)))
+
+
 setup(
     name = 'quantlib',
     version = '0.1',
     author = 'Didrik Pinte,Patrick Henaff',
     license = 'BSD',
     packages = find_packages(),
+    include_package_data = True,
     ext_modules = collect_extensions(),
-    cmdclass = {'build_ext': build_ext},
+    cmdclass = {'build_ext': pyql_build_ext},
     install_requires = ['distribute', 'tabulate', 'pandas', 'six'],
     zip_safe = False
 )


### PR DESCRIPTION
On windows include the quantlib dlls (and optionally the c runtime dlls, which
can be useful if not using the default version of visual studio) in the quantlib
package. This means that it can be installed from an egg or wheel without
having to also have the quantlib dll somewhere else on the system path.

Also some minor changes to reduce the amount of manual changes
required to setup.py and generate_symbols.py for swiching between x86
and x64.