### PR TITLE
Add classmethods for overloaded Schedule constructor; add tests.

### DIFF
--- a/quantlib/test/test_schedule.py
+++ b/quantlib/test/test_schedule.py
@@ -44,7 +44,7 @@ class ScheduleMethodTestCase(unittest.TestCase):
         self.termination_convention = Preceding
         self.rule = Twentieth
 
-        self.schedule = Schedule(
+        self.schedule = Schedule.from_effective_termination(
             self.from_date, self.to_date, self.tenor, self.calendar,
             self.convention, self.termination_convention, self.rule
         )
@@ -88,20 +88,41 @@ class ScheduleMethodTestCase(unittest.TestCase):
         termination_convention = Following
         rule = Forward
 
-        fwd_schedule = Schedule(from_date, to_date, tenor, calendar, convention,
-                termination_convention, rule)
+        fwd_schedule = Schedule.from_effective_termination(from_date, to_date,
+                tenor, calendar, convention, termination_convention, rule)
 
         expected_date = Date(5, Sep, 2011)
         self.assert_(expected_date == fwd_schedule.next_date(from_date))
 
         rule = Backward
 
-        bwd_schedule = Schedule(from_date, to_date, tenor, calendar, convention,
-                termination_convention, rule)
+        bwd_schedule = Schedule.from_effective_termination(from_date, to_date,
+                tenor, calendar, convention, termination_convention, rule)
 
         expected_date = Date(15, Nov, 2011)
         self.assert_(expected_date == bwd_schedule.previous_date(to_date))
 
+    def test_schedule_from_dates(self):
+        dates = [Date(3, Sep, 2011),
+                 Date(5, Nov, 2011),
+                 Date(15, Dec, 2011)]
+        tenor = Period(1, Months)
+        calendar = UnitedKingdom()
+        convention = Following
+        termination_convention = Following
+        rule = Forward
+
+        schedule = Schedule.from_dates(dates,
+                calendar, convention, termination_convention, tenor, rule)
+
+        expected_date = Date(3, Sep, 2011)
+        self.assert_(expected_date == schedule.next_date(Date(3, Sep, 2011)))
+
+        expected_date = Date(5, Nov, 2011)
+        self.assert_(expected_date == schedule.next_date(Date(4, Sep, 2011)))
+
+        expected_date = Date(15, Dec, 2011)
+        self.assert_(expected_date == schedule.next_date(Date(6, Nov, 2011)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/quantlib/time/_schedule.pxd
+++ b/quantlib/time/_schedule.pxd
@@ -6,6 +6,13 @@ from _period cimport Period
 from _date cimport Date
 from _calendar cimport Calendar, BusinessDayConvention
 
+cdef extern from 'boost/optional.hpp' namespace 'boost':
+    cdef cppclass optional[T]:
+        optional(T)
+        optional(T*)
+
+    cdef int none
+
 cdef extern from 'ql/time/dategenerationrule.hpp' namespace \
         'QuantLib::DateGeneration':
 
@@ -50,6 +57,15 @@ cdef extern from 'ql/time/schedule.hpp' namespace 'QuantLib':
                  bool endOfMonth,
                  Date& firstDate,
                  Date& nextToLastDate
+        ) except +
+        Schedule(vector[Date]& dates,
+                 Calendar& calendar,
+                 BusinessDayConvention convention,
+                 optional[BusinessDayConvention] terminationDateConvention,
+                 optional[Period] tenor,
+                 optional[Rule] rule,
+                 optional[bool] endOfMonth,
+                 vector[bool]& isRegular
         ) except +
 
         Size size()

--- a/quantlib/time/schedule.pxd
+++ b/quantlib/time/schedule.pxd
@@ -2,4 +2,3 @@ cimport _schedule
 
 cdef class Schedule:
     cdef _schedule.Schedule* _thisptr
-

--- a/quantlib/time/schedule.pyx
+++ b/quantlib/time/schedule.pyx
@@ -1,5 +1,7 @@
 from cython.operator cimport dereference as deref
+from libcpp cimport bool
 from libcpp.vector cimport vector
+from _schedule cimport optional
 
 cimport _schedule
 cimport _date
@@ -8,6 +10,7 @@ cimport _calendar
 from calendar cimport DateList, Calendar
 from date cimport date_from_qldate, Date, Period
 
+import warnings
 
 cdef public enum Rule:
     # Backward from termination date to effective date.
@@ -39,26 +42,82 @@ cdef public enum Rule:
 cdef class Schedule:
     """ Payment schedule. """
 
+    def __init__(self, Date effective_date=None, Date termination_date=None,
+            Period tenor=None, Calendar calendar=None,
+            int business_day_convention=_calendar.Following,
+            int termination_date_convention=_calendar.Following,
+            int date_generation_rule=Forward, end_of_month=False,
+            from_classmethod=False
+           ):
 
-    def __init__(self, Date effective_date, Date termination_date,
+        if not from_classmethod:
+            warnings.warn("Deprecated: use class methods from_effective_termination instead",
+                DeprecationWarning)
+
+            if not (effective_date and termination_date and tenor and calendar):
+                raise ValueError(
+                    "Must specify effective_date, termination_date, tenor, and calendar")
+            self._thisptr = new _schedule.Schedule(
+                deref(effective_date._thisptr.get()),
+                deref(termination_date._thisptr.get()),
+                deref(tenor._thisptr.get()),
+                deref(calendar._thisptr),
+                <_calendar.BusinessDayConvention>business_day_convention,
+                <_calendar.BusinessDayConvention>termination_date_convention,
+                <_schedule.Rule>date_generation_rule, <bool>end_of_month
+            )
+        else:
+            pass
+
+    @classmethod
+    def from_dates(cls, dates, Calendar calendar, int business_day_convention=_calendar.Following,
+            int termination_date_convention=_calendar.Following, Period tenor=None,
+            int date_generation_rule=Forward, end_of_month=False, is_regular=[]):
+        # convert lists to vectors
+        cdef vector[_date.Date] _dates = vector[_date.Date]()
+        for date in dates:
+            _dates.push_back(deref((<Date>date)._thisptr.get()))
+
+        cdef vector[bool] _is_regular = vector[bool]()
+        for regular in is_regular:
+            _is_regular.push_back(regular)
+
+        cdef Schedule instance = cls(from_classmethod=True)
+        instance._thisptr = new _schedule.Schedule(
+            _dates,
+            deref(calendar._thisptr),
+            <_calendar.BusinessDayConvention>business_day_convention,
+            optional[_calendar.BusinessDayConvention](
+                <_calendar.BusinessDayConvention>termination_date_convention),
+            (optional[_calendar.Period](deref(tenor._thisptr.get())) if tenor
+                else <optional[_calendar.Period]>_schedule.none),
+            optional[_schedule.Rule](<_schedule.Rule>date_generation_rule),
+            optional[bool](<bool>end_of_month),
+            _is_regular
+        )
+
+        return instance
+
+    @classmethod
+    def from_effective_termination(cls, Date effective_date, Date termination_date,
             Period tenor, Calendar calendar,
             int business_day_convention=_calendar.Following,
             int termination_date_convention=_calendar.Following,
-           int date_generation_rule=Forward, end_of_month=False):
-
-        self._thisptr = new _schedule.Schedule(
-            deref(effective_date._thisptr.get()),
-            deref(termination_date._thisptr.get()),
-            deref(tenor._thisptr.get()),
-            deref(calendar._thisptr),
-            <_calendar.BusinessDayConvention>business_day_convention,
-            <_calendar.BusinessDayConvention>termination_date_convention,
-            <_schedule.Rule>date_generation_rule, end_of_month
-        )
-
+            int date_generation_rule=Forward, end_of_month=False):
+        cdef Schedule instance = cls(from_classmethod=True)
+        instance._thisptr = new _schedule.Schedule(
+                deref(effective_date._thisptr.get()),
+                deref(termination_date._thisptr.get()),
+                deref(tenor._thisptr.get()),
+                deref(calendar._thisptr),
+                <_calendar.BusinessDayConvention>business_day_convention,
+                <_calendar.BusinessDayConvention>termination_date_convention,
+                <_schedule.Rule>date_generation_rule, <bool>end_of_month
+            )
+        return instance
 
     def __dealloc__(self):
-        if self._thisptr is NULL:
+        if self._thisptr is not NULL:
             del self._thisptr
             self._thisptr = NULL
 


### PR DESCRIPTION
Implementation of overloaded `Schedule` constructors according to discussion at https://github.com/enthought/pyql/issues/112.
