### PR TITLE
Cleanup api

### DIFF
--- a/examples/bonds.py
+++ b/examples/bonds.py
@@ -12,7 +12,7 @@ from quantlib.time.api import (
 from quantlib.compounding import Continuous
 from quantlib.pricingengines.bond import DiscountingBondEngine
 from quantlib.time.date import Date, August, Period, Jul, Annual, Years
-from quantlib.time.daycounter import Actual365Fixed
+from quantlib.time.daycounters.simple import Actual365Fixed
 from quantlib.time.daycounters.actual_actual import ActualActual, ISMA
 from quantlib.time.schedule import Schedule, Backward
 from quantlib.settings import Settings

--- a/examples/scripts/stovol_calibration.py
+++ b/examples/scripts/stovol_calibration.py
@@ -25,7 +25,8 @@ import datetime
 from six.moves import input
 
 from quantlib.models.equity.heston_model import (
-    HestonModelHelper, HestonModel, ImpliedVolError)
+    HestonModelHelper, HestonModel)
+from quantlib.models.calibration_helper import ImpliedVolError
 from quantlib.models.equity.bates_model import (BatesModel,
                                                 BatesDetJumpModel,
                                                 BatesDoubleExpModel)

--- a/quantlib/indexes/api.py
+++ b/quantlib/indexes/api.py
@@ -10,6 +10,7 @@
 from .libor import Libor
 from .euribor import Euribor, Euribor6M
 from .ibor_index import IborIndex
+from .swap_index import SwapIndex
 
 from .region_registry import region_from_name
 from .region import Region, CustomRegion

--- a/quantlib/instruments/api.py
+++ b/quantlib/instruments/api.py
@@ -1,6 +1,7 @@
-from .bonds import FixedRateBond, ZeroCouponBond
-from .credit_default_swap import CreditDefaultSwap
+from .bonds import FixedRateBond, ZeroCouponBond, FloatingRateBond
+from .credit_default_swap import CreditDefaultSwap, SELLER, BUYER
 from .option import EuropeanExercise, AmericanExercise, VanillaOption
 from .option import DividendVanillaOption, EuropeanOption
 from .payoffs import Put, Call, PlainVanillaPayoff, PAYOFF_TO_STR
 from .instrument import Instrument
+from .swap import VanillaSwap, Payer, Receiver

--- a/quantlib/mlab/fixed_income.py
+++ b/quantlib/mlab/fixed_income.py
@@ -16,9 +16,10 @@ from quantlib.compounding import Compounded
 
 from quantlib.pricingengines.bond import DiscountingBondEngine
 from quantlib.time.calendar import (
-    TARGET, Unadjusted, ModifiedFollowing, Following)
+    Unadjusted, ModifiedFollowing, Following)
 
 from quantlib.time.calendars.null_calendar import NullCalendar
+from quantlib.time.calendars.target import TARGET
 from quantlib.time.date import (
     Date, Days, Period, Years, str_to_frequency)
 

--- a/quantlib/mlab/term_structure.py
+++ b/quantlib/mlab/term_structure.py
@@ -7,7 +7,7 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 """
 
-from quantlib.time.calendar import TARGET
+from quantlib.time.calendars.target import TARGET
 from quantlib.settings import Settings
 from quantlib.time.schedule import Schedule
 

--- a/quantlib/models/api.py
+++ b/quantlib/models/api.py
@@ -1,0 +1,4 @@
+from .hestonmodel import HestonModelHelper, HestonMode
+from .batesmodel import (BatesModel, BatesDetJumpModel, BatesDoubleExpModel,
+    BatesDoubleExpDetJumpModel)
+from .calibration_helper import (RelativePriceError, PriceError, ImpliedVolError)

--- a/quantlib/models/equity/heston_model.pyx
+++ b/quantlib/models/equity/heston_model.pyx
@@ -35,11 +35,6 @@ from quantlib.termstructures.yields.flat_forward cimport (
 from quantlib.models.calibration_helper cimport CalibrationHelper
 
 
-cdef public enum CALIBRATION_ERROR_TYPE:
-    RelativePriceError = _ch.RelativePriceError
-    PriceError = _ch.PriceError
-    ImpliedVolError = _ch.ImpliedVolError
-
 cdef class HestonModelHelper(CalibrationHelper):
 
     def __cinit__(self):
@@ -56,7 +51,7 @@ cdef class HestonModelHelper(CalibrationHelper):
         Quote volatility,
         YieldTermStructure risk_free_rate,
         YieldTermStructure dividend_yield,
-        error_type=RelativePriceError
+        error_type=_ch.RelativePriceError
     ):
         # create handles
         cdef Handle[_qt.Quote] volatility_handle = \

--- a/quantlib/termstructures/yields/api.py
+++ b/quantlib/termstructures/yields/api.py
@@ -1,6 +1,7 @@
 from .bond_helpers import BondHelper, FixedRateBondHelper
 from .flat_forward import FlatForward
 from .piecewise_yield_curve import PiecewiseYieldCurve
+from .forward_spreaded_term_structure import ForwardSpreadedTermStructure
 from .rate_helpers import (
     RateHelper, DepositRateHelper, FraRateHelper,
     FuturesRateHelper, SwapRateHelper)

--- a/quantlib/test/test_bonds.py
+++ b/quantlib/test/test_bonds.py
@@ -5,12 +5,13 @@ from quantlib.instruments.bonds import (
 )
 from quantlib.pricingengines.bond import DiscountingBondEngine
 from quantlib.time.calendar import (
-    TARGET, Unadjusted, ModifiedFollowing, Following
+    Unadjusted, ModifiedFollowing, Following
 )
 from quantlib.time.calendars.united_states import (
     UnitedStates, GOVERNMENTBOND, SETTLEMENT
 )
 from quantlib.time.calendars.null_calendar import NullCalendar
+from quantlib.time.calendars.target import TARGET
 from quantlib.compounding import Compounded, Continuous
 from quantlib.time.date import (
     Date, Days, Semiannual, January, August, Period, March, February,Oct,Nov,

--- a/quantlib/test/test_bonds.py
+++ b/quantlib/test/test_bonds.py
@@ -17,7 +17,7 @@ from quantlib.time.date import (
     Date, Days, Semiannual, January, August, Period, March, February,Oct,Nov,
     Jul, Annual, Years, Quarterly
 )
-from quantlib.time.daycounter import Actual365Fixed, Actual360
+from quantlib.time.daycounters.simple import Actual365Fixed, Actual360
 from quantlib.time.daycounters.actual_actual import ActualActual, Bond, ISMA
 from quantlib.time.schedule import Schedule, Backward
 from quantlib.settings import Settings

--- a/quantlib/test/test_bucketanalysis.py
+++ b/quantlib/test/test_bucketanalysis.py
@@ -3,7 +3,8 @@ from .unittest_tools import unittest
 
 from quantlib.instruments.bonds import (FixedRateBond)
 from quantlib.pricingengines.bond import DiscountingBondEngine
-from quantlib.time.calendar import ( TARGET, Unadjusted, ModifiedFollowing, Following)
+from quantlib.time.calendar import ( Unadjusted, ModifiedFollowing, Following)
+from quantlib.time.calendars.target import TARGET
 from quantlib.time.calendars.united_states import ( UnitedStates, GOVERNMENTBOND)
 from quantlib.currency.api import USDCurrency
 from quantlib.instruments.option import VanillaOption

--- a/quantlib/test/test_calendar.py
+++ b/quantlib/test/test_calendar.py
@@ -1,9 +1,10 @@
 from .unittest_tools import unittest
 
 from quantlib.time.calendar import (
-    Following, ModifiedFollowing, ModifiedPreceding, Preceding, TARGET,
+    Following, ModifiedFollowing, ModifiedPreceding, Preceding,
     holiday_list
 )
+from quantlib.time.calendars.target import TARGET
 from quantlib.time.calendars.united_kingdom import UnitedKingdom, EXCHANGE
 from quantlib.time.calendars.united_states import UnitedStates, NYSE
 from quantlib.time.calendars.canada import Canada, TSX

--- a/quantlib/test/test_calendar_registry.py
+++ b/quantlib/test/test_calendar_registry.py
@@ -3,7 +3,7 @@ from quantlib.test.unittest_tools import unittest
 from quantlib.time.calendar_registry import (
    initialize_code_registry, calendar_from_name
 )
-from quantlib.time.calendar import TARGET
+from quantlib.time.calendars.target import TARGET
 from quantlib.time.calendars.united_states import UnitedStates
 
 class CalendarRegistryTestCase(unittest.TestCase):

--- a/quantlib/test/test_cython_bug.pyx
+++ b/quantlib/test/test_cython_bug.pyx
@@ -9,8 +9,9 @@ from quantlib.time._date cimport (
 )
 from quantlib.time._period cimport Years, Period, Annual, Days
 from quantlib.time._calendar cimport (
-    Calendar, TARGET, Unadjusted, ModifiedFollowing, Following
+    Calendar, Unadjusted, ModifiedFollowing, Following
 )
+from quantlib.time.calendars._target cimport TARGET
 from quantlib.time._schedule cimport Schedule, Backward
 from quantlib.time.date cimport date_from_qldate, Date
 from quantlib.time.daycounters._actual_actual cimport ISMA, ActualActual

--- a/quantlib/test/test_daycounter.py
+++ b/quantlib/test/test_daycounter.py
@@ -1,7 +1,9 @@
 from .unittest_tools import unittest
 
-from quantlib.time.daycounter import (
-    Actual360, DayCounter, SimpleDayCounter
+from quantlib.time.daycounter import DayCounter
+
+from quantlib.time.daycounters.simple import (
+    Actual360, SimpleDayCounter
 )
 
 from quantlib.time.daycounters.actual_actual import (

--- a/quantlib/test/test_heston_model.py
+++ b/quantlib/test/test_heston_model.py
@@ -6,8 +6,9 @@ from .unittest_tools import unittest
 
 from quantlib.instruments.option import EuropeanExercise, VanillaOption
 from quantlib.instruments.payoffs import Call, PlainVanillaPayoff, Put
+from quantlib.models.calibration_helper import ImpliedVolError
 from quantlib.models.equity.heston_model import (
-    HestonModelHelper, HestonModel, ImpliedVolError
+    HestonModelHelper, HestonModel
 )
 
 from quantlib.processes.heston_process import HestonProcess

--- a/quantlib/test/test_hhw_calibration.py
+++ b/quantlib/test/test_hhw_calibration.py
@@ -18,12 +18,12 @@ from quantlib.quotes import SimpleQuote
 from quantlib.termstructures.yields.flat_forward import FlatForward
 
 from quantlib.models.equity.heston_model import (
-    HestonModelHelper, HestonModel, PriceError
+    HestonModelHelper, HestonModel
 )
 
-from quantlib.processes.heston_process import HestonProcess
+from quantlib.models.calibration_helper import PriceError
 
-from quantlib.processes.api import HullWhiteProcess
+from quantlib.processes.api import HullWhiteProcess, HestonProcess
 
 from quantlib.pricingengines.api import (
     AnalyticHestonEngine,

--- a/quantlib/test/test_termstructures.py
+++ b/quantlib/test/test_termstructures.py
@@ -16,7 +16,7 @@ from quantlib.quotes import SimpleQuote
 from quantlib.settings import Settings
 from quantlib.time.calendars.target import TARGET
 from quantlib.time.calendars.null_calendar import NullCalendar
-from quantlib.time.daycounter import Actual360, Actual365Fixed
+from quantlib.time.daycounters.simple import Actual360, Actual365Fixed
 from quantlib.time.date import today, Days
 
 from quantlib.compounding import Simple

--- a/quantlib/test/test_termstructures.py
+++ b/quantlib/test/test_termstructures.py
@@ -9,7 +9,7 @@
 
 from .unittest_tools import unittest
 from quantlib.termstructures.yields.api import (
-    FlatForward, YieldTermStructure
+    FlatForward, YieldTermStructure, ForwardSpreadedTermStructure
 )
 from quantlib.quotes import SimpleQuote
 
@@ -23,7 +23,6 @@ from quantlib.compounding import Simple
 from quantlib.time.api import Date, Actual360
 from quantlib.market.market import libor_market, IborMarket
 from quantlib.quotes import SimpleQuote
-from quantlib.termstructures.yields.forward_spreaded_term_structure import ForwardSpreadedTermStructure
 
 class SimpleQuoteTestCase(unittest.TestCase):
 

--- a/quantlib/test/test_termstructures.py
+++ b/quantlib/test/test_termstructures.py
@@ -14,7 +14,7 @@ from quantlib.termstructures.yields.api import (
 from quantlib.quotes import SimpleQuote
 
 from quantlib.settings import Settings
-from quantlib.time.calendar import TARGET
+from quantlib.time.calendars.target import TARGET
 from quantlib.time.calendars.null_calendar import NullCalendar
 from quantlib.time.daycounter import Actual360, Actual365Fixed
 from quantlib.time.date import today, Days

--- a/quantlib/time/_calendar.pxd
+++ b/quantlib/time/_calendar.pxd
@@ -9,7 +9,7 @@ from _period cimport Period, TimeUnit
 
 
 cdef extern from 'ql/time/businessdayconvention.hpp' namespace 'QuantLib':
-    cdef enum BusinessDayConvention: 
+    cdef enum BusinessDayConvention:
         #ISDA
         Following          # Choose the first business day after
                            #     the given holiday. */
@@ -50,10 +50,3 @@ cdef extern from 'ql/time/calendar.hpp' namespace 'QuantLib':
     #cdef vector[Date] 'Calendar::holidayList'(Calendar& calendar, Date& f, Date& to, bool includeWeekEnds)
     cdef vector[Date] Calendar_holidayList 'QuantLib::Calendar::holidayList'(Calendar&
             calendar, Date& from_date, Date& to_date, int includeWeekEnds)
-
-
-cdef extern from 'ql/time/calendars/target.hpp' namespace 'QuantLib':
-    cdef cppclass TARGET(Calendar):
-        TARGET()
-
-

--- a/quantlib/time/_daycounter.pxd
+++ b/quantlib/time/_daycounter.pxd
@@ -14,36 +14,3 @@ cdef extern from 'ql/time/daycounter.hpp' namespace 'QuantLib':
         string name()
         BigInteger dayCount(Date&, Date&)
         Time yearFraction(Date&, Date&, Date&, Date&)
-
-cdef extern from 'ql/time/daycounters/thirty360.hpp' namespace 'QuantLib':
-
-    cdef cppclass Thirty360(DayCounter):
-        pass
-
-cdef extern from 'ql/time/daycounters/actual360.hpp' namespace 'QuantLib':
-
-    cdef cppclass Actual360(DayCounter):
-        pass
-
-cdef extern from 'ql/time/daycounters/actual365fixed.hpp' namespace 'QuantLib':
-
-    cdef cppclass Actual365Fixed(DayCounter):
-        pass
-
-        
-cdef extern from 'ql/time/daycounters/business252.hpp' namespace 'QuantLib':
-
-    cdef cppclass Business252(DayCounter):
-        Business252(Calendar c)
-
-
-cdef extern from 'ql/time/daycounters/one.hpp' namespace 'QuantLib':
-
-    cdef cppclass OneDayCounter(DayCounter):
-        pass
-
-cdef extern from 'ql/time/daycounters/simpledaycounter.hpp' namespace 'QuantLib':
-
-    cdef cppclass SimpleDayCounter(DayCounter):
-        pass
-

--- a/quantlib/time/api.py
+++ b/quantlib/time/api.py
@@ -19,6 +19,8 @@ from .calendars.weekends_only import WeekendsOnly
 from .calendars.united_kingdom import UnitedKingdom
 from .calendars.united_states import UnitedStates
 from .calendars.canada import Canada
+from .calendars.switzerland import Switzerland
+from .calendars.japan import Japan
 
 from .daycounter import Actual360, Actual365Fixed, DayCounter
 from .daycounters.thirty360 import Thirty360

--- a/quantlib/time/api.py
+++ b/quantlib/time/api.py
@@ -23,7 +23,8 @@ from .calendars.switzerland import Switzerland
 from .calendars.japan import Japan
 from .calendars.target import TARGET
 
-from .daycounter import Actual360, Actual365Fixed, DayCounter
+from .daycounter import DayCounter
+from .daycounters.simple import Actual360, Actual365Fixed
 from .daycounters.thirty360 import Thirty360
 from .daycounters.actual_actual import (ActualActual, ISMA, ISDA, Bond,
     Historical, Actual365, AFB, Euro)

--- a/quantlib/time/api.py
+++ b/quantlib/time/api.py
@@ -9,7 +9,7 @@
 
 from .businessdayconvention import BusinessDayConvention
 from .calendar import (
-    Calendar, TARGET, ModifiedFollowing, Following, ModifiedPreceding,
+    Calendar, ModifiedFollowing, Following, ModifiedPreceding,
     Preceding, Unadjusted, holiday_list
     )
 from .calendar_registry import calendar_from_name
@@ -21,6 +21,7 @@ from .calendars.united_states import UnitedStates
 from .calendars.canada import Canada
 from .calendars.switzerland import Switzerland
 from .calendars.japan import Japan
+from .calendars.target import TARGET
 
 from .daycounter import Actual360, Actual365Fixed, DayCounter
 from .daycounters.thirty360 import Thirty360

--- a/quantlib/time/calendar.pyx
+++ b/quantlib/time/calendar.pyx
@@ -191,22 +191,3 @@ def holiday_list(Calendar calendar, date.Date from_date, date.Date to_date,
     t = DateList()
     t._set_dates(dates)
     return t
-
-cdef class TARGET(Calendar):
-    '''TARGET calendar
-
-    Holidays (see http://www.ecb.int):
-
-     * Saturdays
-     * Sundays
-     * New Year's Day, January 1st
-     * Good Friday (since 2000)
-     * Easter Monday (since 2000)
-     * Labour Day, May 1st (since 2000)
-     * Christmas, December 25th
-     * Day of Goodwill, December 26th (since 2000)
-     * December 31st (1998, 1999, and 2001)
-    '''
-
-    def __cinit__(self):
-        self._thisptr = <_calendar.Calendar*> new _calendar.TARGET()

--- a/quantlib/time/calendar_registry.py
+++ b/quantlib/time/calendar_registry.py
@@ -6,7 +6,7 @@ import quantlib.time.calendars.united_kingdom as uk
 import quantlib.time.calendars.japan as jp
 import quantlib.time.calendars.switzerland as sw
 import quantlib.time.calendars.canada as ca
-from quantlib.time.calendar import TARGET
+from quantlib.time.calendars.target import TARGET
 from quantlib.util.object_registry import ObjectRegistry
 
 #ISO-3166 country codes (http://en.wikipedia.org/wiki/ISO_3166-1)

--- a/quantlib/time/calendars/_target.pxd
+++ b/quantlib/time/calendars/_target.pxd
@@ -1,0 +1,5 @@
+from quantlib.time._calendar cimport Calendar
+
+cdef extern from 'ql/time/calendars/target.hpp' namespace 'QuantLib':
+    cdef cppclass TARGET(Calendar):
+        TARGET()

--- a/quantlib/time/calendars/target.pyx
+++ b/quantlib/time/calendars/target.pyx
@@ -1,0 +1,21 @@
+cimport quantlib.time.calendars._target as _tg
+from quantlib.time.calendar cimport Calendar
+
+cdef class TARGET(Calendar):
+    '''TARGET calendar
+
+    Holidays (see http://www.ecb.int):
+
+     * Saturdays
+     * Sundays
+     * New Year's Day, January 1st
+     * Good Friday (since 2000)
+     * Easter Monday (since 2000)
+     * Labour Day, May 1st (since 2000)
+     * Christmas, December 25th
+     * Day of Goodwill, December 26th (since 2000)
+     * December 31st (1998, 1999, and 2001)
+    '''
+
+    def __cinit__(self):
+        self._thisptr = new _tg.TARGET()

--- a/quantlib/time/daycounter.pyx
+++ b/quantlib/time/daycounter.pyx
@@ -3,13 +3,11 @@ from libcpp.string cimport string
 
 cimport _daycounter
 cimport _date
-cimport _calendar
-cimport quantlib.time.calendars._target as _tg
 
 from date cimport Date
-from calendar cimport Calendar
 from quantlib.time.daycounters.actual_actual cimport from_name as aa_from_name
 from quantlib.time.daycounters.thirty360 cimport from_name as th_from_name
+cimport quantlib.time.daycounters._simple as _simple
 
 cdef class DayCounter:
     '''This class provides methods for determining the length of a time
@@ -109,17 +107,17 @@ cdef _daycounter.DayCounter* daycounter_from_name(basestring name, basestring co
 
     cdef _daycounter.DayCounter* cnt = NULL
     if name_u in ['ACTUAL360', 'ACTUAL/360', 'ACT/360']:
-        cnt = new _daycounter.Actual360()
+        cnt = new _simple.Actual360()
     elif name_u in ['ACTUAL365FIXED', 'ACTUAL/365', 'ACT/365']:
-        cnt = new _daycounter.Actual365Fixed()
+        cnt = new _simple.Actual365Fixed()
     elif name_u == 'BUSINESS252':
         raise ValueError(
             'Business252 from name is not supported. Requires a calendar'
         )
     elif name_u in ['1/1', 'ONEDAYCOUNTER']:
-        cnt = new _daycounter.OneDayCounter()
+        cnt = new _simple.OneDayCounter()
     elif name_u == 'SIMPLEDAYCOUNTER':
-        cnt = new _daycounter.SimpleDayCounter()
+        cnt = new _simple.SimpleDayCounter()
     elif name.startswith('Actual/Actual') or name.startswith('ACT/ACT') :
         cnt = aa_from_name(convention)
     elif name.startswith('30/360'):
@@ -127,36 +125,3 @@ cdef _daycounter.DayCounter* daycounter_from_name(basestring name, basestring co
             convention = 'BONDBASIS'
         cnt = th_from_name(convention)
     return cnt
-
-
-cdef class Actual360(DayCounter):
-
-    def __cinit__(self, *args):
-        self._thisptr = <_daycounter.DayCounter*> new _daycounter.Actual360()
-
-
-cdef class Actual365Fixed(DayCounter):
-
-    def __cinit__(self, *args):
-        self._thisptr = <_daycounter.DayCounter*> new _daycounter.Actual365Fixed()
-
-
-cdef class Business252(DayCounter):
-
-    def __cinit__(self, *args, calendar=None):
-        cdef _calendar.Calendar* cl
-        if calendar is None:
-           cl = new _tg.TARGET()
-        else:
-           cl = (<Calendar>calendar)._thisptr
-        self._thisptr = <_daycounter.DayCounter*> new _daycounter.Business252(deref(cl))
-
-cdef class OneDayCounter(DayCounter):
-
-    def __cinit__(self, *args):
-        self._thisptr = <_daycounter.DayCounter*> new _daycounter.OneDayCounter()
-
-cdef class SimpleDayCounter(DayCounter):
-
-    def __cinit__(self, *args):
-        self._thisptr = <_daycounter.DayCounter*> new _daycounter.SimpleDayCounter()

--- a/quantlib/time/daycounter.pyx
+++ b/quantlib/time/daycounter.pyx
@@ -4,6 +4,7 @@ from libcpp.string cimport string
 cimport _daycounter
 cimport _date
 cimport _calendar
+cimport quantlib.time.calendars._target as _tg
 
 from date cimport Date
 from calendar cimport Calendar
@@ -145,7 +146,7 @@ cdef class Business252(DayCounter):
     def __cinit__(self, *args, calendar=None):
         cdef _calendar.Calendar* cl
         if calendar is None:
-           cl = <_calendar.Calendar*> new _calendar.TARGET()
+           cl = new _tg.TARGET()
         else:
            cl = (<Calendar>calendar)._thisptr
         self._thisptr = <_daycounter.DayCounter*> new _daycounter.Business252(deref(cl))
@@ -159,4 +160,3 @@ cdef class SimpleDayCounter(DayCounter):
 
     def __cinit__(self, *args):
         self._thisptr = <_daycounter.DayCounter*> new _daycounter.SimpleDayCounter()
-

--- a/quantlib/time/daycounters/_simple.pxd
+++ b/quantlib/time/daycounters/_simple.pxd
@@ -1,0 +1,28 @@
+from quantlib.time._daycounter cimport DayCounter
+from quantlib.time._calendar cimport Calendar
+
+cdef extern from 'ql/time/daycounters/actual365fixed.hpp' namespace 'QuantLib':
+
+    cdef cppclass Actual365Fixed(DayCounter):
+        pass
+
+cdef extern from 'ql/time/daycounters/actual360.hpp' namespace 'QuantLib':
+
+    cdef cppclass Actual360(DayCounter):
+        pass
+
+cdef extern from 'ql/time/daycounters/business252.hpp' namespace 'QuantLib':
+
+    cdef cppclass Business252(DayCounter):
+        Business252(Calendar c)
+
+
+cdef extern from 'ql/time/daycounters/one.hpp' namespace 'QuantLib':
+
+    cdef cppclass OneDayCounter(DayCounter):
+        pass
+
+cdef extern from 'ql/time/daycounters/simpledaycounter.hpp' namespace 'QuantLib':
+
+    cdef cppclass SimpleDayCounter(DayCounter):
+        pass

--- a/quantlib/time/daycounters/simple.pxd
+++ b/quantlib/time/daycounters/simple.pxd
@@ -1,0 +1,18 @@
+cimport quantlib.time._daycounter as _daycounter
+from quantlib.time.daycounter cimport DayCounter
+
+
+cdef class Actual365Fixed(DayCounter):
+    pass
+
+cdef class Actual360(DayCounter):
+    pass
+
+cdef class Business252(DayCounter):
+    pass
+
+cdef class OneDayCounter(DayCounter):
+    pass
+
+cdef class SimpleDayCounter(DayCounter):
+    pass

--- a/quantlib/time/daycounters/simple.pyx
+++ b/quantlib/time/daycounters/simple.pyx
@@ -1,0 +1,45 @@
+"""This module contains "simple" Daycounter classes, i.e. which do not depend on
+a convention"""
+
+from cython.operator cimport dereference as deref
+
+cimport quantlib.time._daycounter as _daycounter
+cimport _simple
+from quantlib.time.daycounter cimport DayCounter
+cimport quantlib.time.calendars._target as _tg
+cimport quantlib.time._calendar as _calendar
+from quantlib.time.calendar cimport Calendar
+
+cdef class Actual365Fixed(DayCounter):
+
+    def __cinit__(self, *args):
+        self._thisptr = <_daycounter.DayCounter*> new _simple.Actual365Fixed()
+
+
+cdef class Actual360(DayCounter):
+
+    def __cinit__(self, *args):
+        self._thisptr = <_daycounter.DayCounter*> new _simple.Actual360()
+
+
+cdef class Business252(DayCounter):
+
+    def __cinit__(self, *args, calendar=None):
+        cdef _calendar.Calendar* cl
+        if calendar is None:
+           cl = new _tg.TARGET()
+        else:
+           cl = (<Calendar>calendar)._thisptr
+        self._thisptr = <_daycounter.DayCounter*> new _simple.Business252(deref(cl))
+
+
+cdef class OneDayCounter(DayCounter):
+
+    def __cinit__(self, *args):
+        self._thisptr = <_daycounter.DayCounter*> new _simple.OneDayCounter()
+
+
+cdef class SimpleDayCounter(DayCounter):
+
+    def __cinit__(self, *args):
+        self._thisptr = <_daycounter.DayCounter*> new _simple.SimpleDayCounter()


### PR DESCRIPTION
Some small cleanups based of the feedback from PR #134
- moved TARGET calendar under calendars.
- moved all the DayCounters under daycounters. (daycounters.simple actually). They can be further split up if need be.
- removed the enum CALIBRATION_ERROR_TYPE from heston_model since it's already defined in calibration_helper. 
- add some functions in the api files, when they were missing.