### PR TITLE
Better constructors for rate_helpers

### DIFF
--- a/quantlib/market/market.py
+++ b/quantlib/market/market.py
@@ -74,7 +74,7 @@ def make_rate_helper(market, quote, reference_date=None):
         forward_date = next_imm_date(reference_date, tenor)
 
         helper = FuturesRateHelper(
-            rate =SimpleQuote(quote_value),
+            price =SimpleQuote(quote_value),
             imm_date = qldate_from_pydate(forward_date),
             length_in_months = 3,
             calendar = market._floating_rate_index.fixing_calendar,
@@ -88,7 +88,7 @@ def make_rate_helper(market, quote, reference_date=None):
         # evaluation date, as for ED futures. To achieve this, we pass the
         # `imm_date` in the `tenor` field of the quote.
         helper = FuturesRateHelper(
-            rate=SimpleQuote(quote_value),
+            price=SimpleQuote(quote_value),
             imm_date=tenor,
             length_in_months=3,
             calendar=market._floating_rate_index.fixing_calendar,

--- a/quantlib/termstructures/yields/_rate_helpers.pxd
+++ b/quantlib/termstructures/yields/_rate_helpers.pxd
@@ -61,6 +61,14 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
                       BusinessDayConvention convention,
                       bool endOfMonth,
                       DayCounter& dayCounter) except +
+        FraRateHelper(Rate rate,
+                      Natural monthsToStart,
+                      Natural monthsToEnd,
+                      Natural fixingDays,
+                      Calendar& calendar,
+                      BusinessDayConvention convention,
+                      bool endOfMonth,
+                      DayCounter& dayCounter) except +
 
 
     cdef cppclass SwapRateHelper(RelativeDateRateHelper):
@@ -71,8 +79,10 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
                        BusinessDayConvention fixedConvention,
                        DayCounter& fixedDayCount,
                        shared_ptr[_ib.IborIndex]& iborIndex,
+                       Handle[Quote]& spread,
+                       Period& fwdStart
         ) except +
-        SwapRateHelper(Handle[Quote]& rate,
+        SwapRateHelper(Rate rate,
                        Period& tenor,
                        Calendar& calendar,
                        Frequency& fixedFrequency,
@@ -84,14 +94,12 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
         ) except +
         SwapRateHelper(Handle[Quote]& rate,
                        shared_ptr[SwapIndex]& swapIndex,
-                       #Handle[Quote]& spread, # = Handle<Quote>(),
-                       #Period& fwdStart, # = 0*Days,
+                       Handle[Quote]& spread, # = Handle<Quote>(),
+                       Period& fwdStart, # = 0*Days,
                        # exogenous discounting curve
                        #Handle[YieldTermStructure]& discountingCurve
                                             #= Handle<YieldTermStructure>()
         ) except +
-
-
         SwapRateHelper(Rate rate,
                        shared_ptr[SwapIndex]& swapIndex,
                        Handle[Quote]& spread, # = Handle<Quote>(),
@@ -109,5 +117,15 @@ cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
                           Calendar& calendar,
                           BusinessDayConvention convention,
                           bool endOfMonth,
-                          DayCounter& dayCounter) except +
-
+                          DayCounter& dayCounter,
+                          Handle[Quote]& convexity_adjustment,
+        ) except +
+        FuturesRateHelper(Real price,
+                          Date& immDate,
+                          Natural lengthInMonths,
+                          Calendar& calendar,
+                          BusinessDayConvention convention,
+                          bool endOfMonth,
+                          DayCounter& dayCounter,
+                          Rate convexity_adjustment,
+        ) except +

--- a/quantlib/termstructures/yields/_rate_helpers.pxd
+++ b/quantlib/termstructures/yields/_rate_helpers.pxd
@@ -28,8 +28,13 @@ from quantlib.termstructures._helpers cimport BootstrapHelper, \
 
 cdef extern from 'ql/termstructures/yield/ratehelpers.hpp' namespace 'QuantLib':
 
-    ctypedef BootstrapHelper[YieldTermStructure] RateHelper
-    ctypedef RelativeDateBootstrapHelper[YieldTermStructure] RelativeDateRateHelper
+    cdef cppclass RateHelper:
+        Date latestDate() except +
+        Handle[Quote] quote()
+        Real impliedQuote() except +
+
+    cdef cppclass RelativeDateRateHelper(RateHelper):
+        void update()
 
     cdef cppclass DepositRateHelper(RateHelper):
         DepositRateHelper(Handle[Quote]& rate,

--- a/quantlib/termstructures/yields/rate_helpers.pxd
+++ b/quantlib/termstructures/yields/rate_helpers.pxd
@@ -4,6 +4,5 @@ from quantlib.handle cimport shared_ptr
 cdef class RateHelper:
     cdef shared_ptr[_rh.RateHelper]* _thisptr
 
-cdef class RelativeDateRateHelper:
-    cdef shared_ptr[_rh.RelativeDateRateHelper]* _thisptr
-    
+cdef class RelativeDateRateHelper(RateHelper):
+    pass

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -49,27 +49,13 @@ cdef class RateHelper:
             return self._thisptr.get().impliedQuote()
 
 
-cdef class RelativeDateRateHelper:
+cdef class RelativeDateRateHelper(RateHelper):
 
     def __cinit__(self):
         self._thisptr = NULL
 
-    def __dealloc__(self):
-        if self._thisptr is not NULL:
-            del self._thisptr
-            self._thisptr = NULL
 
-    property quote:
-        def __get__(self):
-            cdef shared_ptr[_qt.Quote] quote_ptr = shared_ptr[_qt.Quote](self._thisptr.get().quote().currentLink())
-            return quote_ptr.get().value()
-
-    property implied_quote:
-        def __get__(self):
-            return self._thisptr.get().impliedQuote()
-
-
-cdef class DepositRateHelper(RateHelper):
+cdef class DepositRateHelper(RelativeDateRateHelper):
     """Rate helper for bootstrapping over deposit rates."""
 
     def __init__(self, rate, Period tenor = None, Natural fixing_days=2,
@@ -137,7 +123,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
                 ' from_index or from_tenor'
             )
 
-    cdef set_ptr(self, shared_ptr[_rh.RelativeDateRateHelper]* ptr):
+    cdef set_ptr(self, shared_ptr[_rh.RateHelper]* ptr):
         self._thisptr = ptr
 
     @classmethod
@@ -153,7 +139,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         cdef SwapRateHelper instance = cls(from_classmethod=True)
 
         if isinstance(rate, float):
-            instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
+            instance.set_ptr(new shared_ptr[_rh.RateHelper](
                 new _rh.SwapRateHelper(
                     <Rate>rate,
                     deref(tenor._thisptr.get()),
@@ -167,7 +153,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
                   )
               )
         elif isinstance(rate, SimpleQuote):
-            instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
+            instance.set_ptr(new shared_ptr[_rh.RateHelper](
                 new _rh.SwapRateHelper(
                     Handle[_qt.Quote](deref((<SimpleQuote>rate)._thisptr)),
                     deref(tenor._thisptr.get()),
@@ -193,7 +179,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         cdef SwapRateHelper instance = cls(from_classmethod=True)
 
         if isinstance(rate, float):
-            instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
+            instance.set_ptr(new shared_ptr[_rh.RateHelper](
                 new _rh.SwapRateHelper(
                     <Rate>rate,
                     deref(<shared_ptr[_si.SwapIndex]*>index._thisptr),
@@ -204,7 +190,7 @@ cdef class SwapRateHelper(RelativeDateRateHelper):
         )
         elif isinstance(rate, SimpleQuote):
             rate_handle = Handle[_qt.Quote](deref((<SimpleQuote>rate)._thisptr))
-            instance.set_ptr(new shared_ptr[_rh.RelativeDateRateHelper](
+            instance.set_ptr(new shared_ptr[_rh.RateHelper](
                 new _rh.SwapRateHelper(
                     rate_handle,
                     deref(<shared_ptr[_si.SwapIndex]*>index._thisptr),
@@ -227,7 +213,7 @@ cdef class FraRateHelper(RelativeDateRateHelper):
             DayCounter day_counter):
 
         if isinstance(rate, float):
-            self._thisptr = new shared_ptr[_rh.RelativeDateRateHelper](
+            self._thisptr = new shared_ptr[_rh.RateHelper](
                 new _rh.FraRateHelper(
                     <Rate>rate,
                     months_to_start,
@@ -240,7 +226,7 @@ cdef class FraRateHelper(RelativeDateRateHelper):
                 )
                  )
         elif isinstance(rate, SimpleQuote):
-            self._thisptr = new shared_ptr[_rh.RelativeDateRateHelper](
+            self._thisptr = new shared_ptr[_rh.RateHelper](
                 new _rh.FraRateHelper(
                     Handle[_qt.Quote](deref((<SimpleQuote>rate)._thisptr)),
                     months_to_start,

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -19,7 +19,7 @@ cimport quantlib.indexes._ibor_index as _ib
 cimport quantlib.indexes._swap_index as _si
 from quantlib.time._period cimport Frequency, Days
 from quantlib.time._calendar cimport BusinessDayConvention
-
+from quantlib.time.date cimport date_from_qldate
 from quantlib.quotes cimport Quote, SimpleQuote
 from quantlib.time.calendar cimport Calendar
 from quantlib.time.daycounter cimport DayCounter
@@ -48,11 +48,14 @@ cdef class RateHelper:
         def __get__(self):
             return self._thisptr.get().impliedQuote()
 
+    @property
+    def latest_date(self):
+        return date_from_qldate(self._thisptr.get().latestDate())
 
 cdef class RelativeDateRateHelper(RateHelper):
 
-    def __cinit__(self):
-        self._thisptr = NULL
+    def update(self):
+        return (<_rh.RelativeDateRateHelper*>self._thisptr.get()).update()
 
 
 cdef class DepositRateHelper(RelativeDateRateHelper):

--- a/quantlib/test/test_rate_helpers.py
+++ b/quantlib/test/test_rate_helpers.py
@@ -12,6 +12,7 @@ from quantlib.time.api import (
     Period, Months, TARGET, ModifiedFollowing, Actual365Fixed, Date, Years,
     UnitedStates, Actual360, Annual
 )
+from quantlib.settings import Settings
 
 class RateHelpersTestCase(unittest.TestCase):
 
@@ -40,6 +41,20 @@ class RateHelpersTestCase(unittest.TestCase):
         self.assertEqual(quote.value, helper_from_quote.quote)
         self.assertEqual(helper_from_quote.quote, helper_from_float.quote)
 
+    def test_relativedate_rate_helper(self):
+        tenor = Period(3, Months)
+        fixing_days = 3
+        calendar =  TARGET()
+        convention = ModifiedFollowing
+        end_of_month = True
+        deposit_day_counter = Actual365Fixed()
+
+        helper = DepositRateHelper(
+            0.005, tenor, fixing_days, calendar, convention, end_of_month,
+            deposit_day_counter
+        )
+        Settings.instance().evaluation_date = Date(8, 6, 2016)
+        self.assertEqual(helper.latest_date, Date(13, 9, 2016))
 
     def test_create_fra_rate_helper(self):
 


### PR DESCRIPTION
allow to pass a float instead of a Quote
- for SwapRateHelper, the code was intended to work like that, but
  wasn't working
- also fixed a bug in DepositRateHelper where end_of_month was never
  used