### PR TITLE
MidpointCdsEngine should depend on the base class

### DIFF
--- a/quantlib/pricingengines/credit.pyx
+++ b/quantlib/pricingengines/credit.pyx
@@ -16,12 +16,12 @@ from engine cimport PricingEngine
 
 cimport quantlib.termstructures._default_term_structure as _dts
 cimport quantlib.termstructures._yield_term_structure as _yts
-from quantlib.termstructures.credit.piecewise_default_curve cimport PiecewiseDefaultCurve
+from quantlib.termstructures.default_term_structure cimport DefaultProbabilityTermStructure
 from quantlib.termstructures.yields.yield_term_structure cimport YieldTermStructure
 
 cdef class MidPointCdsEngine(PricingEngine):
 
-    def __init__(self, PiecewiseDefaultCurve ts, double recovery_rate,
+    def __init__(self, DefaultProbabilityTermStructure ts, double recovery_rate,
                  YieldTermStructure discount_curve):
         """
         First argument should be a DefaultProbabilityTermStructure. Using


### PR DESCRIPTION
that way we can build an engine from a FlatHazardRate curve.