### PR TITLE
Allocate all vectors on the stack

### DIFF
--- a/quantlib/experimental/risk/sensitivityanalysis.pyx
+++ b/quantlib/experimental/risk/sensitivityanalysis.pyx
@@ -16,7 +16,7 @@ cdef public enum SensitivityAnalysis:
     Centered
  
 def bucket_analysis(quotes_vvsq, instruments,
-                    quantity, shift, sa_type):
+                    vector[Real] quantity, shift, sa_type):
 
     """ Parameters :
     ----------
@@ -33,9 +33,8 @@ def bucket_analysis(quotes_vvsq, instruments,
     """
 
     #C++ Inputs
-    cdef vector[vector[Handle[_qt.SimpleQuote]]]* vvh_quotes = new vector[vector[Handle[_qt.SimpleQuote]]]()
-    cdef vector[shared_ptr[_it.Instrument]]* vsp_instruments = new vector[shared_ptr[_it.Instrument]]()
-    cdef vector[Real]* rates = new vector[Real]()
+    cdef vector[vector[Handle[_qt.SimpleQuote]]] vvh_quotes
+    cdef vector[shared_ptr[_it.Instrument]] vsp_instruments
    
     #intermediary temps
     cdef vector[Handle[_qt.SimpleQuote]] sqh_vector
@@ -46,9 +45,6 @@ def bucket_analysis(quotes_vvsq, instruments,
     #C++ Output
     cdef pair[vector[vector[Real]],vector[vector[Real]]] ps
 	
-	
-    for rate in quantity:
-        rates.push_back(rate)
 	
     for qlinstrument in instruments:
         instrument_sp = deref((<Instrument>qlinstrument)._thisptr)
@@ -64,9 +60,9 @@ def bucket_analysis(quotes_vvsq, instruments,
 			
         vvh_quotes.push_back(sqh_vector)
 
-    ps = _sa.bucketAnalysis(deref(vvh_quotes),
-                            deref(vsp_instruments),
-                            deref(rates),
+    ps = _sa.bucketAnalysis(vvh_quotes,
+                            vsp_instruments,
+                            quantity,
                             shift,
                             sa_type)
     

--- a/quantlib/models/equity/heston_model.pyx
+++ b/quantlib/models/equity/heston_model.pyx
@@ -119,28 +119,25 @@ cdef class HestonModel:
         def __get__(self):
             return self._thisptr.get().v0()
 
-    def calibrate(self, helpers, OptimizationMethod method, EndCriteria
+    def calibrate(self, list helpers, OptimizationMethod method, EndCriteria
             end_criteria, Constraint constraint=None):
 
         #convert list to vector
-        cdef vector[shared_ptr[_ch.CalibrationHelper]]* helpers_vector = \
-            new vector[shared_ptr[_ch.CalibrationHelper]]()
+        cdef vector[shared_ptr[_ch.CalibrationHelper]] helpers_vector
 
-        cdef shared_ptr[_ch.CalibrationHelper]* chelper
+        cdef shared_ptr[_ch.CalibrationHelper] chelper
         for helper in helpers:
-            chelper = new shared_ptr[_ch.CalibrationHelper](
-                (<HestonModelHelper>helper)._thisptr.get()
-            )
-            helpers_vector.push_back(deref(chelper))
+            chelper = deref((<HestonModelHelper>helper)._thisptr)
+            helpers_vector.push_back(chelper)
 
         if constraint is None:
             self._thisptr.get().calibrate(
-                deref(helpers_vector),
+                helpers_vector,
                 deref(method._thisptr.get()),
                 deref(end_criteria._thisptr.get()))
         else:
             self._thisptr.get().calibrate(
-                deref(helpers_vector),
+                helpers_vector,
                 deref(method._thisptr.get()),
                 deref(end_criteria._thisptr.get()),
                 deref(constraint._thisptr.get()))

--- a/quantlib/models/shortrate/onefactormodels/hullwhite.pyx
+++ b/quantlib/models/shortrate/onefactormodels/hullwhite.pyx
@@ -76,22 +76,19 @@ cdef class HullWhite(Vasicek):
         def __get__(self):
             return (<_hw.HullWhite*> self._thisptr.get()).sigma()
 
-    def calibrate(self, helpers, OptimizationMethod method, EndCriteria
+    def calibrate(self, list helpers, OptimizationMethod method, EndCriteria
             end_criteria):
 
         #convert list to vector
-        cdef vector[shared_ptr[_ch.CalibrationHelper]]* helpers_vector = \
-            new vector[shared_ptr[_ch.CalibrationHelper]]()
+        cdef vector[shared_ptr[_ch.CalibrationHelper]] helpers_vector
 
-        cdef shared_ptr[_ch.CalibrationHelper]* chelper
+        cdef shared_ptr[_ch.CalibrationHelper] chelper
         for helper in helpers:
-            chelper = new shared_ptr[_ch.CalibrationHelper](
-                (<CalibrationHelper>helper)._thisptr.get()
-            )
-            helpers_vector.push_back(deref(chelper))
+            chelper = deref((<CalibrationHelper>helper)._thisptr)
+            helpers_vector.push_back(chelper)
 
         (<_hw.HullWhite*> self._thisptr.get()).calibrate(
-            deref(helpers_vector),
+            helpers_vector,
             deref(method._thisptr.get()),
             deref(end_criteria._thisptr.get())
         )

--- a/quantlib/termstructures/inflation/seasonality.pyx
+++ b/quantlib/termstructures/inflation/seasonality.pyx
@@ -74,28 +74,21 @@ cdef class Seasonality:
 
 cdef class MultiplicativePriceSeasonality(Seasonality):
 
-    def __init__(self, Date d, Frequency frequency, seasonality_factors):
-        cdef vector[Rate] _seasonality_factors = vector[Rate]()
-        for sf in seasonality_factors:
-            _seasonality_factors.push_back(sf)
+    def __init__(self, Date d, Frequency frequency, vector[Rate] seasonality_factors):
         self._thisptr = new shared_ptr[_se.Seasonality](
             new _se.MultiplicativePriceSeasonality(
                 deref(d._thisptr.get()),
                 frequency,
-                _seasonality_factors))
+                seasonality_factors))
 
     def set(self, Date seasonality_base_date,
             Frequency frequency,
-            seasonality_factors):
-
-        cdef vector[Rate] _seasonality_factors = vector[Rate]()
-        for sf in seasonality_factors:
-            _seasonality_factors.push_back(sf)
+            vector[Rate] seasonality_factors):
 
         (<_se.MultiplicativePriceSeasonality*> self._thisptr.get()).set(
                 deref(seasonality_base_date._thisptr.get()),
                 frequency,
-                _seasonality_factors)
+                seasonality_factors)
             
     property seasonality_base_date:
         def __get__(self):
@@ -108,11 +101,7 @@ cdef class MultiplicativePriceSeasonality(Seasonality):
 
     property seasonality_factors:
         def __get__(self):
-            cdef vector[Rate] sf = (<_se.MultiplicativePriceSeasonality*> self._thisptr.get()).seasonalityFactors()
-            sf_list = []
-            for i in xrange(sf.size()):
-                sf_list.append(sf.at(i))
-            return sf_list
+            return (<_se.MultiplicativePriceSeasonality*> self._thisptr.get()).seasonalityFactors()
 
     def seasonality_factor(self, Date d):
         return (<_se.MultiplicativePriceSeasonality*> self._thisptr.get()).seasonalityFactor(

--- a/quantlib/termstructures/yields/piecewise_yield_curve.pyx
+++ b/quantlib/termstructures/yields/piecewise_yield_curve.pyx
@@ -60,8 +60,7 @@ cdef class PiecewiseYieldCurve(YieldTermStructure):
         cdef string interpolator_string = interpolator.encode('utf-8')
 
         # convert Python list to std::vector
-        cdef vector[shared_ptr[_rh.RateHelper]]* instruments = \
-                new vector[shared_ptr[_rh.RateHelper]]()
+        cdef vector[shared_ptr[_rh.RateHelper]] instruments
 
         for helper in helpers:
             instruments.push_back(
@@ -74,7 +73,7 @@ cdef class PiecewiseYieldCurve(YieldTermStructure):
                         trait_string,
                         interpolator_string,
                         deref(settlement_date._thisptr.get()),
-                        deref(instruments),
+                        instruments,
                         deref(day_counter._thisptr),
                         tolerance
                 )

--- a/quantlib/termstructures/yields/zero_curve.pyx
+++ b/quantlib/termstructures/yields/zero_curve.pyx
@@ -11,25 +11,21 @@ from quantlib.time.date cimport Date
 
 cdef class ZeroCurve(YieldTermStructure):
 
-    def __init__(self, dates, yields, DayCounter daycounter):
+    def __init__(self, list dates, vector[Rate] yields, DayCounter daycounter):
 
         # convert dates and yields to vector
-        cdef vector[_zc.Date]* _date_vector = new vector[_zc.Date]()
-        cdef vector[Rate]* _yield_vector = new vector[Rate]()
+        cdef vector[_zc.Date] _date_vector = vector[_zc.Date]()
 
         # highly inefficient and could be improved
         for date in dates:
             _date_vector.push_back(deref((<Date>date)._thisptr.get()))
 
-        for rate in yields:
-            _yield_vector.push_back(rate)
-
         # create the curve
         self._thisptr = new shared_ptr[Handle[_zc.YieldTermStructure]](
             new Handle[_zc.YieldTermStructure](shared_ptr[_zc.YieldTermStructure](
                 new _zc.ZeroCurve(
-                    deref(_date_vector),
-                    deref(_yield_vector),
+                    _date_vector,
+                    yields,
                     deref(daycounter._thisptr)))
             )
         )

--- a/quantlib/test/test_cython_bug.pyx
+++ b/quantlib/test/test_cython_bug.pyx
@@ -73,14 +73,14 @@ cdef FixedRateBond* get_bond_for_evaluation_date(QlDate& in_date):
 
     cdef QlDate issue_date = QlDate(10, Jul, 2006)
 
-    cdef vector[Rate]* coupons = new vector[Rate]()
+    cdef vector[Rate] coupons
     coupons.push_back(coupon_rate)
 
     cdef FixedRateBond* bond = new FixedRateBond(
             settlement_days,
 		    face_amount,
 		    fixed_bond_schedule,
-		    deref(coupons),
+		    coupons,
             ActualActual(ISMA),
 		    Following,
             redemption,


### PR DESCRIPTION
- no need to clean up memory afterwards
- also cython can convert list of double to vectors transparently