### PR TITLE
Fix returns of daycounters

### DIFF
--- a/quantlib/indexes/interest_rate_index.pyx
+++ b/quantlib/indexes/interest_rate_index.pyx
@@ -65,8 +65,9 @@ cdef class InterestRateIndex(Index):
 
     property day_counter:
         def __get__(self):
-            cdef _dc.DayCounter dc = get_iri(self).dayCounter()
-            return DayCounter.from_name(dc.name().decode('utf-8'))
+            cdef DayCounter dc = DayCounter()
+            dc._thisptr = new _dc.DayCounter(get_iri(self).dayCounter())
+            return dc
 
     def fixing_date(self, Date valueDate):
         cdef _dt.Date dt = deref(valueDate._thisptr.get())

--- a/quantlib/interest_rate.pyx
+++ b/quantlib/interest_rate.pyx
@@ -18,6 +18,7 @@ from quantlib import compounding
 from quantlib.time.api import NoFrequency, Once
 from quantlib.time.date import frequency_to_str
 from quantlib.time.daycounter cimport DayCounter
+cimport quantlib.time._daycounter as _daycounter
 
 cdef class InterestRate:
     """ This class encapsulate the interest rate compounding algebra.
@@ -69,9 +70,9 @@ cdef class InterestRate:
 
     property day_counter:
         def __get__(self):
-            cdef _ir.DayCounter dc = self._thisptr.get().dayCounter()
-
-            return DayCounter.from_name(dc.name().decode('utf-8'))
+            cdef DayCounter dc = DayCounter()
+            dc._thisptr = new _daycounter.DayCounter(self._thisptr.get().dayCounter())
+            return dc
 
     def __repr__(self):
         if self.rate == None:

--- a/quantlib/termstructures/yields/yield_term_structure.pyx
+++ b/quantlib/termstructures/yields/yield_term_structure.pyx
@@ -231,8 +231,9 @@ cdef class YieldTermStructure:
         def __get__(self):
             self._raise_if_empty()
             cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
-            cdef _dc.DayCounter dc = term_structure.dayCounter()
-            return DayCounter.from_name(dc.name())
+            cdef DayCounter dc = DayCounter()
+            dc._thisptr = new _dc.DayCounter(term_structure.dayCounter())
+            return dc
 
     property settlement_days:
         def __get__(self):

--- a/quantlib/test/test_interest_rate.py
+++ b/quantlib/test/test_interest_rate.py
@@ -3,8 +3,8 @@ from .unittest_tools import unittest
 from quantlib.interest_rate import InterestRate
 
 from quantlib.compounding import Continuous, Compounded
-from quantlib.time.api import Actual360, Monthly, NoFrequency, Once
-
+from quantlib.time.api import Actual360, Monthly, NoFrequency, Once, Thirty360
+from quantlib.time.daycounters.thirty360 import Thirty360, ITALIAN
 
 class InterestRateTestCase(unittest.TestCase):
 
@@ -52,6 +52,14 @@ class InterestRateTestCase(unittest.TestCase):
         for frequency in [Once, NoFrequency]:
             with self.assertRaises(RuntimeError):
                 InterestRate(rate, counter, compounding, frequency)
+
+    def test_create_intereste_rate_with_daycounter_convention(self):
+        rate = 0.05
+        counter = Thirty360(ITALIAN)
+        compounding = Compounded
+        frequency = Monthly
+        interest_rate = InterestRate(rate, counter, compounding, frequency)
+        self.assertEqual(interest_rate.day_counter, counter)
 
     def test_repr(self):
 

--- a/quantlib/time/_daycounter.pxd
+++ b/quantlib/time/_daycounter.pxd
@@ -10,6 +10,7 @@ cdef extern from 'ql/time/daycounter.hpp' namespace 'QuantLib':
 
     cdef cppclass DayCounter:
         DayCounter()
+        DayCounter(const DayCounter&)
         bool empty()
         string name()
         BigInteger dayCount(Date&, Date&)


### PR DESCRIPTION
If dc is a DayCounter, it's not true that in general that:
  dc = DayCounter.from_name(dc.name())
The method from_name needs fixing, but that's for another day.