### PR TITLE
Better docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,44 +6,59 @@ original source but keeping a Pythonic simple access to classes, methods and
 functions. Most of the complex structures related to proper memory management
 are completely hidden being the Python layers (for example boost::shared_ptr and Handle).
 
-quantlib
---------
-
-.. currentmodule:: quantlib.currency
-
-.. autoclass:: Currency
-    :members:
-    :undoc-members:
-    :noindex:
-
-.. currentmodule:: quantlib.settings
-
-.. autoclass:: Settings
-    :members:
-    :undoc-members:
-    :noindex:
+:mod:`quantlib`
+---------------
 
 :mod:`quantlib.settings`
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: quantlib.settings
     :members:
     :undoc-members:
     :noindex:
 
 :mod:`quantlib.quotes`
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: quantlib.quotes
     :members:
     :undoc-members:
-    :noindex:
+
+:mod:`quantlib.cashflow`
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.cashflow
+    :members:
+    :undoc-members:
+
+:mod:`quantlib.index`
+^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.index
+    :members:
+    :undoc-members:
+
+:mod:`quantlib.interest_rate`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.interest_rate
+    :members:
+
+:mod:`quantlib.currency`
+------------------------
+
+:mod:`quantlib.currency.currency`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: quantlib.currency.currency
+    :members:
+    :undoc-members:
+
+:mod:`quantlib.currency.currencies`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: quantlib.currency.currencies
+    :members:
+    :undoc-members:
+
 
 :mod:`quantlib.indexes`
 -----------------------
-.. currentmodule:: quantlib.index
-
-.. autoclass:: Index
-    :members:
-    :noindex:
 
 .. currentmodule:: quantlib.indexes.interest_rate_index
 
@@ -69,47 +84,33 @@ quantlib
     :members:
     :noindex:
 
-quantlib.instruments
---------------------
+:mod:`quantlib.instruments`
+---------------------------
 
-.. currentmodule:: quantlib.instruments.bonds
-
-.. autoclass:: Bond
+:mod:`quantlib.instruments.bonds`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.instruments.bonds
     :members:
-    :noindex:
 
-.. autoclass:: FixedRateBond
+:mod:`quantlib.instruments.option`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.instruments.option
     :members:
-    :noindex:
 
-.. autoclass:: ZeroCouponBond
+:mod:`quantlib.instruments.credit_default_swap`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.instruments.credit_default_swap
     :members:
-    :noindex:
 
-.. currentmodule:: quantlib.instruments.option
-
-.. autosummary::
-
-.. autoclass:: VanillaOption
-    :members:
-    :noindex:
+.. currentmodule:: quantlib.instruments.credit_default_swap
+.. autodata
 
 quantlib.math
 -------------
 
-.. currentmodule:: quantlib.math.optimization
-
-.. autoclass:: OptimizationMethod
+.. automodule:: quantlib.math.optimization
     :members:
-    :noindex:
-
-.. autoclass:: LevenbergMarquardt
-    :members:
-    :noindex:
-
-.. autoclass:: EndCriteria
-    :members:
-    :noindex:
+    :undoc-members:
 
 
 quantlib.model.equity
@@ -125,65 +126,23 @@ quantlib.model.equity
     :members:
     :noindex:
 
-.. currentmodule:: quantlib.models.equity.bates_model
-
-.. autoclass:: BatesModel
+.. automodule:: quantlib.models.equity.bates_model
     :members:
-    :noindex:
-
-.. autoclass:: BatesDetJumpModel
-    :members:
-    :noindex:
-
-.. autoclass:: BatesDoubleExpModel
-    :members:
-    :noindex:
-
-.. autoclass:: BatesDoubleExpDetJumpModel
-    :members:
-    :noindex:
 
 :mod:`quantlib.pricingengines`
 ------------------------------
 
 .. automodule:: quantlib.pricingengines.blackformula
 
-.. automodule:: quantlib.pricingengines.engine
+.. automodule:: quantlib.pricingengines.vanilla.vanilla
+   :members:
+   :undoc-members:
 
-.. automodule:: quantlib.pricingengines.vanilla
-.. currentmodule:: quantlib.pricingengines.vanilla.vanilla
-
-.. autoclass:: VanillaOptionEngine
-    :members:
-    :noindex:
-
-.. autoclass:: AnalyticEuropeanEngine
-    :members:
-    :noindex:
-
-.. autoclass:: AnalyticHestonEngine
-    :members:
-    :noindex:
-
-.. autoclass:: BaroneAdesiWhaleyApproximationEngine
-    :members:
-    :noindex:
-
-.. autoclass:: BatesEngine
-    :members:
-    :noindex:
-
-.. autoclass:: BatesDetJumpEngine
-    :members:
-    :noindex:
-
-.. autoclass:: BatesDoubleExpEngine
-    :members:
-    :noindex:
-
-.. autoclass:: BatesDoubleExpDetJumpEngine
-    :members:
-    :noindex:
+:mod:`quantlib.pricingengines.swaption`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.pricingengines.swaption
+   :members:
+   :undoc-members:
 
 :mod:`quantlib.processes`
 -------------------------
@@ -217,77 +176,113 @@ quantlib.model.equity
    :members:
    :noindex:
 
-.. currentmodule:: quantlib.termstructures.yields.api
+:mod:`quantlib.termstructures.inflation_term_structure`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.termstructures.inflation_term_structure
+   :members:
 
-.. autoclass:: YieldTermStructure
+
+:mod:`quantlib.termstructures.default_term_structure`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.termstructures.default_term_structure
+   :members:
+   :undoc-members:
+
+:mod:`quantlib.termstructures.yields`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:mod:`~quantlib.termstructures.yields.yield_term_structure`
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.yields.yield_term_structure
+   :members:
+   :undoc-members:
+
+:mod:`~quantlib.termstructures.yields.rate_helpers`
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.yields.rate_helpers
     :members:
     :noindex:
 
-.. autoclass:: FlatForward
-    :members:
-
-.. autoclass:: ZeroCurve
-    :members:
-    :noindex:
-
-.. autoclass:: RateHelper
+:mod:`~quantlib.termstructures.yields.bond_helpers`
+""""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.yields.bond_helpers
     :members:
     :noindex:
 
-.. autoclass:: DepositRateHelper
-    :members:
-    :noindex:
-
-.. automodule:: quantlib.termstructures.yields.piecewise_yield_curve
+:mod:`~quantlib.termstructures.yields.flat_forward`
+""""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.yields.flat_forward
     :members:
 
-.. automodule:: quantlib.termstructures.credit.flat_forward
+:mod:`~quantlib.termstructures.yields.zero_curve`
+""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.yields.zero_curve
     :members:
 
-.. automodule:: quantlib.termstructures.credit.interpolated_hazardrate_curve
-    :members:
 
-.. autoclass:: FlatForward
-    :members:
-    :noindex:
+:mod:`quantlib.termstructures.credit`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+:mod:`~quantlib.termstructures.credit.default_probability_helpers`
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 .. automodule:: quantlib.termstructures.credit.default_probability_helpers
     :members:
     :noindex:
 
+:mod:`~quantlib.termstructures.credit.piecewise_default_curve`
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 .. automodule:: quantlib.termstructures.credit.piecewise_default_curve
     :members:
     :noindex:
 
+:mod:`~quantlib.termstructures.credit.flat_hazard_rate`
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 .. automodule:: quantlib.termstructures.credit.flat_hazard_rate
     :members:
     :noindex:
 
+:mod:`~quantlib.termstructures.credit.interpolated_hazardrate_curve`
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.termstructures.credit.interpolated_hazardrate_curve
+    :members:
+
 :mod:`quantlib.time`
 --------------------
 
+:mod:`quantlib.time.date`
+^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: quantlib.time.date
     :members:
     :undoc-members:
+.. autodata::
 
-.. py:data:: quantlib.time.date.Months
-.. data:: quantlib.time.date.Days
-
-.. currentmodule:: quantlib.time.calendar 
-
-.. autoclass:: Calendar
+:mod:`quantlib.time.calendar`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: quantlib.time.calendar
     :members:
-    :noindex:
 
 .. autoclass:: TARGET
 
-.. autofunction:: holiday_list
-
+:mod:`quantlib.time.daycounter`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: quantlib.time.daycounter
    :members:
 
+:mod:`quantlib.time.daycounters`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:mod:`~quantlib.time.daycounters.simple`
+""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.time.daycounters.simple
+   :members:
+   :undoc-members:
+
+:mod:`~quantlib.time.daycounters.thirty360`
+"""""""""""""""""""""""""""""""""""""""""""
+.. automodule:: quantlib.time.daycounters.thirty360
+   :members:
+
+:mod:`quantlib.time.schedule`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: quantlib.time.schedule
     :members:
-
-
-

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,68 +13,78 @@ quantlib
 
 .. autoclass:: Currency
     :members:
-
-.. autoclass:: USDCurrency
-    :members:
-
-.. autoclass:: EURCurrency
-    :members:
+    :undoc-members:
+    :noindex:
 
 .. currentmodule:: quantlib.settings
 
 .. autoclass:: Settings
     :members:
+    :undoc-members:
+    :noindex:
 
-.. currentmodule:: quantlib.quotes
-
-.. autoclass:: Quote
+:mod:`quantlib.settings`
+------------------------
+.. automodule:: quantlib.settings
     :members:
+    :undoc-members:
+    :noindex:
 
-.. autoclass:: SimpleQuote
+:mod:`quantlib.quotes`
+----------------------
+.. automodule:: quantlib.quotes
     :members:
+    :undoc-members:
+    :noindex:
 
-quantlib.indexes
-----------------
-
+:mod:`quantlib.indexes`
+-----------------------
 .. currentmodule:: quantlib.index
 
 .. autoclass:: Index
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.indexes.interest_rate_index
 
 .. autoclass:: InterestRateIndex
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.indexes.ibor_index
 
 .. autoclass:: IborIndex
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.indexes.euribor
 
 .. autoclass:: Euribor
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.indexes.libor
 
 .. autoclass:: Libor
     :members:
+    :noindex:
 
 quantlib.instruments
 --------------------
-
 
 .. currentmodule:: quantlib.instruments.bonds
 
 .. autoclass:: Bond
     :members:
+    :noindex:
 
 .. autoclass:: FixedRateBond
     :members:
+    :noindex:
 
 .. autoclass:: ZeroCouponBond
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.instruments.option
 
@@ -82,6 +92,7 @@ quantlib.instruments
 
 .. autoclass:: VanillaOption
     :members:
+    :noindex:
 
 quantlib.math
 -------------
@@ -90,12 +101,15 @@ quantlib.math
 
 .. autoclass:: OptimizationMethod
     :members:
+    :noindex:
 
 .. autoclass:: LevenbergMarquardt
     :members:
+    :noindex:
 
 .. autoclass:: EndCriteria
     :members:
+    :noindex:
 
 
 quantlib.model.equity
@@ -105,104 +119,124 @@ quantlib.model.equity
 
 .. autoclass:: HestonModel
     :members:
+    :noindex:
 
 .. autoclass:: HestonModelHelper
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.models.equity.bates_model
 
 .. autoclass:: BatesModel
     :members:
+    :noindex:
 
 .. autoclass:: BatesDetJumpModel
     :members:
+    :noindex:
 
 .. autoclass:: BatesDoubleExpModel
     :members:
+    :noindex:
 
 .. autoclass:: BatesDoubleExpDetJumpModel
     :members:
+    :noindex:
 
-quantlib.pricingengines
------------------------
+:mod:`quantlib.pricingengines`
+------------------------------
 
 .. automodule:: quantlib.pricingengines.blackformula
 
 .. automodule:: quantlib.pricingengines.engine
 
-.. currentmodule:: quantlib.pricingengines.vanilla
+.. automodule:: quantlib.pricingengines.vanilla
+.. currentmodule:: quantlib.pricingengines.vanilla.vanilla
 
 .. autoclass:: VanillaOptionEngine
     :members:
+    :noindex:
 
 .. autoclass:: AnalyticEuropeanEngine
     :members:
+    :noindex:
 
 .. autoclass:: AnalyticHestonEngine
     :members:
+    :noindex:
 
 .. autoclass:: BaroneAdesiWhaleyApproximationEngine
     :members:
+    :noindex:
 
 .. autoclass:: BatesEngine
     :members:
+    :noindex:
 
 .. autoclass:: BatesDetJumpEngine
     :members:
+    :noindex:
 
 .. autoclass:: BatesDoubleExpEngine
     :members:
+    :noindex:
 
 .. autoclass:: BatesDoubleExpDetJumpEngine
     :members:
+    :noindex:
 
-quantlib.processes
-------------------
+:mod:`quantlib.processes`
+-------------------------
 
 .. currentmodule:: quantlib.processes.black_scholes_process
 
 .. autoclass:: GeneralizedBlackScholesProcess
     :members:
+    :noindex:
 
 .. autoclass:: BlackScholesMertonProcess
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.processes.bates_process
 
 .. autoclass:: BatesProcess
     :members:
+    :noindex:
 
 .. currentmodule:: quantlib.processes.heston_process
 
 .. autoclass:: HestonProcess
     :members:
+    :noindex:
 
-quantlib.termstructures
------------------------
+:mod:`quantlib.termstructures`
+------------------------------
 
-.. currentmodule:: quantlib.termstructures.volatility.equityfx.black_vol_term_structure
-
-.. autoclass:: BlackVolTermStructure
-    :members:
-
-.. autoclass:: BlackConstantVol
-    :members:
+.. automodule:: quantlib.termstructures.volatility.equityfx.black_vol_term_structure
+   :members:
+   :noindex:
 
 .. currentmodule:: quantlib.termstructures.yields.api
 
 .. autoclass:: YieldTermStructure
     :members:
+    :noindex:
 
 .. autoclass:: FlatForward
     :members:
 
 .. autoclass:: ZeroCurve
     :members:
+    :noindex:
 
 .. autoclass:: RateHelper
     :members:
+    :noindex:
 
 .. autoclass:: DepositRateHelper
+    :members:
+    :noindex:
 
 .. automodule:: quantlib.termstructures.yields.piecewise_yield_curve
     :members:
@@ -213,35 +247,46 @@ quantlib.termstructures
 .. automodule:: quantlib.termstructures.credit.interpolated_hazardrate_curve
     :members:
 
-quantlib.time
--------------
-
-.. currentmodule:: quantlib.time.date 
-
-.. autoclass:: Date
+.. autoclass:: FlatForward
     :members:
     :noindex:
 
-.. autoclass:: Period
+.. automodule:: quantlib.termstructures.credit.default_probability_helpers
     :members:
+    :noindex:
+
+.. automodule:: quantlib.termstructures.credit.piecewise_default_curve
+    :members:
+    :noindex:
+
+.. automodule:: quantlib.termstructures.credit.flat_hazard_rate
+    :members:
+    :noindex:
+
+:mod:`quantlib.time`
+--------------------
+
+.. automodule:: quantlib.time.date
+    :members:
+    :undoc-members:
+
+.. py:data:: quantlib.time.date.Months
+.. data:: quantlib.time.date.Days
 
 .. currentmodule:: quantlib.time.calendar 
 
 .. autoclass:: Calendar
     :members:
+    :noindex:
 
 .. autoclass:: TARGET
 
 .. autofunction:: holiday_list
 
-.. currentmodule:: quantlib.time.daycounter
+.. automodule:: quantlib.time.daycounter
+   :members:
 
-.. autoclass:: DayCounter
-    :members:
-
-.. currentmodule:: quantlib.time.schedule
-
-.. autoclass:: Schedule
+.. automodule:: quantlib.time.schedule
     :members:
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -128,10 +128,9 @@ quantlib.pricingengines
 
 .. automodule:: quantlib.pricingengines.blackformula
 
-.. currentmodule:: quantlib.pricingengines.vanilla
+.. automodule:: quantlib.pricingengines.engine
 
-.. autoclass:: PricingEngine
-    :members:
+.. currentmodule:: quantlib.pricingengines.vanilla
 
 .. autoclass:: VanillaOptionEngine
     :members:

--- a/docs/source/business_dates.rst
+++ b/docs/source/business_dates.rst
@@ -17,7 +17,7 @@ date handling is also known from Excel. The alternative is the construction via:
 
     Date(day, month, year)
     
-Here, day, month and year are of integer. A set of month constant are available in the date module (January,  ..., December or Jan, ..., Dec)
+Here, day, month and year are of integer. A set of month constant are available in the date module (January, …, December or Jan, …, Dec)
 
 After constructing a Date, we can do simple date arithmetics, such as adding/subtracting days and months to the current date. Furthermore, the known convenient operators such as +=,-= can be used. 
 
@@ -26,35 +26,37 @@ It is possible to add a Period to a date. Period can be created using time units
     Period(frequency)
     Period(lenght, time_units)
     
-Frequencies are define with the following constants : NoFrequency, Once,
+Frequencies are defined with the following constants: NoFrequency, Once,
 Annual, Semiannual, EveryFourthMonth, Quartely, Bimonthly, Monthly,
 EveryFourthWeek, Biweekly, Weekly, Daily and OtherFrequency.
 
-Time units are constants defined in the date module :  Days, Weeks, Months, Years. 
+Time units are constants defined in the date module: :data:`~quantlib.time.date.Days`, :data:`~quantlib.time.date.Weeks`, :data:`~quantlib.time.date.Months`, :data:`~quantlib.time.date.Years`.
 
 
-Each Date object has the following properties :
+Each :class:`~quantlib.time.date.Date` object has the following properties:
 
- * **weekday** returns the weekday using the weekday constants defined in the
+ * :attr:`~quantlib.time.date.Date.weekday` returns the weekday using the weekday constants defined in the
    date module (Sunday to Saturday and Sun to Sat). 
- * **day** returns the day of the month 
- * **day_of_year** returns the day of the year
- * **month** returns the month 
- * **year** returns the year 
- * **serial** returns a the serial number of this date
+ * :attr:`~quantlib.time.date.Date.day` returns the day of the month
+ * :attr:`~quantlib.time.date.Date.day_of_year` returns the day of the year
+ * :attr:`~quantlib.time.date.Date.month` returns the month
+ * :attr:`~quantlib.time.date.Date.year` returns the year
+ * :attr:`~quantlib.time.date.Date.serial` returns a the serial number of this date
 
-The QuantLib Date class has some useful static functions, which give general results, such as whether a given year is a leap year or a given date is the end of the month. The currently available functions are:
+The :mod:`quantlib.time.date` module has some useful static functions,
+which give general results, such as whether a given year is a leap
+year or a given date is the end of the month. The currently available
+functions are:
 
- * **today()**
- * **min_date()**: earliest possible Date in QuantLib
- * **max_date()**: latest possible Date in QuantLib
- * **is_leap(year)**: is year a leap year?
- * **end_of_month(date)**: what is the end of the month in which date is a 
-   day?
- * **is_end_of_month(date)**: is date the end of the month?
- * **next_weekday(date, weekday)**: on which date is the weekday following 
+ * :func:`~quantlib.time.date.today()`
+ * :func:`~quantlib.time.date.mindate()`: earliest possible Date in QuantLib
+ * :func:`~quantlib.time.date.maxdate()`: latest possible Date in QuantLib
+ * :func:`~quantlib.time.date.is_leap()`: is year a leap year?
+ * :func:`~quantlib.time.date.end_of_month()`: what is the end of the current month the date is in?
+ * :func:`~quantlib.time.date.is_end_of_month(date)`: is date the end of the month?
+ * :func:`~quantlib.time.date.next_weekday(date, weekday)`: on which date is the weekday following
    the date? (e.g. date of the next Friday)
- * **nth_weekday(n, weekday, month, year)**: what is the n-th weekday in the 
+ * :func:`~quantlib.time.date.nth_weekday(n, weekday, month, year)`: what is the n-th weekday in the
    given year and month? (e.g. date of the 3rd Wednesday in July 2010)
 
 
@@ -66,7 +68,7 @@ One of the crucial objects in the daily business is a calendar for different cou
     uk_calendar = UnitedKingdom()
 
 for the UK. Calendars implementation are available in the
-quantlib.time.calendars subpackage.
+:mod:`quantlib.time.calendars` subpackage.
 
 Various other calendars are available, for example for Germany, United States, Switzerland, Ukraine, Turkey, Japan, India, Canada and Australia. In addition, special exchange calendars can be initialized for several countries. 
 For example, the New-York Stock Exchange calendar can be initialized via::
@@ -75,21 +77,21 @@ For example, the New-York Stock Exchange calendar can be initialized via::
 
 The following functions are available:
 
- * **is_business_day(date)**
- * **is_holiday(date)**
- * **is_weekend(week_day)**: is the given weekday part of the weekend?
- * **is_end_of_month(date)**: indicates, whether the given date is the last 
+ * :meth:`~quantlib.time.calendar.Calendar.is_business_day(date)`
+ * :meth:`~quantlib.time.calendar.Calendar.is_holiday(date)`
+ * :meth:`~quantlib.time.calendar.Calendar.is_weekend(week_day)`: is the given weekday part of the weekend?
+ * :meth:`~quantlib.time.calendar.Calendar.is_end_of_month(date)`: indicates, whether the given date is the last
    business day in the month.
- * **end_of_month(date)**: returns the last business day in the month.
+ * :meth:`~quantlib.time.calendar.Calendar.end_of_month(date)`: returns the last business day in the month.
 
 The calendars are customizable, so you can add and remove holidays in your calendar: 
 
- * **addHoliday(date)**: adds a user specified holiday
- * **removeHoliday(date)**: removes a user specified holiday
+ * :meth:`~quantlib.time.calendar.Calendar.addHoliday(date)`
+ * :meth:`~quantlib.time.calendar.Calendar.removeHoliday(date)`: removes a user specified holiday
 
 Furthermore, a function is provided to return a list of holidays
 
- * **holidayList(calendar, from_date, to_date, include_weekends=False)**: 
+ * :func:`~quantlib.time.calendar.Calendar.holidayList(calendar, from_date, to_date, include_weekends=False)`:
    returns a holiday list, including or excluding weekends. This function
    returns a DateList object that provides an list/iterator-like interface on
    top of the C++ QuantLib date vector.
@@ -181,7 +183,7 @@ TODO : add example
 Date generation
 ---------------
 
-An often needed functionality is a schedule of payments, for example for coupon payments of a bond. The task is to produce a series of dates from a start to an end date following a given frequency(e.g. annual, quarterly...). We might want the dates to follow a certain business day convention. And we might want the schedule to go backwards (e.g. start the frequency going backwards from the last date). 
+An often needed functionality is a schedule of payments, for example for coupon payments of a bond. The task is to produce a series of dates from a start to an end date following a given frequency(e.g. annual, quarterly…). We might want the dates to follow a certain business day convention. And we might want the schedule to go backwards (e.g. start the frequency going backwards from the last date).
 
 For example:
 
@@ -240,6 +242,3 @@ In [4]: %timeit datetime.date.today() + datetime.timedelta(days=10)
 
 In [5]: %timeit quantlib.date.today() + quantlib.date.Period(10, quantlib.date.Days)
 100000 loops, best of 3: 2.17 us per loop
-
-
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ import sys, os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.abspath('../..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -25,7 +25,9 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+        'sphinx.ext.imgmath', 'sphinx.ext.napoleon']
+napoleon_use_param = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -74,7 +76,7 @@ exclude_patterns = []
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+add_module_names = False
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.

--- a/docs/source/cython_wrapper.rst
+++ b/docs/source/cython_wrapper.rst
@@ -2,12 +2,14 @@ How to wrap QuantLib classes with cython
 ========================================
 
 These notes provide a step by step guide to wrapping a QuantLib (QL) class
-with cython, so that it can be invoked from python. 
+with cython, so that it can be invoked from python.
 
-The objective is to make available in python a set of modules that exactly mirror 
-the QL class hierarchy. For example, QL provides a class 
-named ''SimpleQuote'', that represents a simple price measurement. 
-The C++ class is defined as follows::
+The objective is to make available in python a set of modules that
+exactly mirror the QL class hierarchy. For example, QL provides a
+class named ``SimpleQuote``, that represents a simple price
+measurement. The C++ class is defined as follows:
+
+.. code-block:: c++
 
     class SimpleQuote : public Quote {
       public:
@@ -17,7 +19,7 @@ The C++ class is defined as follows::
         Real setValue(Real value = Null<Real>());
     };
 
-After wrapping the C++ class, this class is now available in python:
+After wrapping the C++ class, this class is now available in python::
 
    from quantlib.quotes import SimpleQuote
    spot = SimpleQuote(3.14)
@@ -25,16 +27,17 @@ After wrapping the C++ class, this class is now available in python:
 
 A couple of observations are worth mentioning:
 
-* pyql preserves the module hierarchy of QuantLib: 
-the SimpleQuote class is defined in the quote module in C++.
+* pyql preserves the module hierarchy of QuantLib:
+  the SimpleQuote class is defined in the quote module in C++.
 
 * pyql exposes QuantLib in a pythonic fashion: instead of exposing the accessor value(),
- pyql implements the property value. 
+  pyql implements the property value.
+
 
 The Interface Code
 ------------------
 
-To expose QL class ''foo'', you need to create three files. For the sake of
+To expose QL class ``foo``, you need to create three files. For the sake of
 standardization, they should be named as follows:
 
 :_foo.pxd: A header file to declare the C++ class being exposed,
@@ -46,32 +49,31 @@ The content of each file is now described in details.
 Declaration of the QL classes to be exposed
 -------------------------------------------
 
-This file contains the declaration of the 
-QL class being exposed. For example, the header file ''_quotes.pxd''
-is as follows:: 
+.. highlight:: cython
 
-    # distutils: language = c++
-    # distutils: libraries = QuantLib
+This file contains the declaration of the QL
+class being exposed. For example, the header file ``_quotes.pxd`` is
+as follows::
 
-    include 'types.pxi'
+  include 'types.pxi'
 
-    from libcpp cimport bool
+  from libcpp cimport bool
 
-    cdef extern from 'ql/quote.hpp' namespace 'QuantLib':
+  cdef extern from 'ql/quote.hpp' namespace 'QuantLib':
 	cdef cppclass Quote:
-	    Quote() except +
-	    Real value() except +
-	    bool isValid() except +
+	   Quote() except +
+	   Real value() except +
+	   bool isValid() except +
 
-    cdef extern from 'ql/quotes/simplequote.hpp' namespace 'QuantLib':
+  cdef extern from 'ql/quotes/simplequote.hpp' namespace 'QuantLib':
 
 	cdef cppclass SimpleQuote(Quote):
-	    SimpleQuote(Real value) except +
-	    Real setValue(Real value) except +
- 
-In this file, we declare the class ''SimpleQuote'' and its parent ''Quote''.
-The syntax is almost identical to the corresponding c++ header file. The 
-types used in declaring arguments are defined in ''types.pxi''.
+	   SimpleQuote(Real value) except +
+	   Real setValue(Real value) except +
+
+In this file, we declare the class ``SimpleQuote`` and its parent ``Quote``.
+The syntax is almost identical to the corresponding C++ header file. The
+types used in declaring arguments are defined in ``types.pxi``.
 
 The clause 'except +' signals that the method may throw an exception. It
 is indispensible to append this clause to every declaration. Without it, an
@@ -80,23 +82,23 @@ exception thrown in QL will terminate the python process.
 Declaration of the python class
 -------------------------------
 
-The second header file declares the python classes that will be wrapping 
-the QL classes. The file ''quotes.pxd'' is reproduced below::
+The second header file declares the python classes that will be wrapping
+the QL classes. The file ``quotes.pxd`` is reproduced below::
 
     cimport _quote as _qt
     from quantlib.handle cimport shared_ptr
 
     cdef class Quote:
-        cdef shared_ptr[_qt.Quote]* _thisptr
+       cdef shared_ptr[_qt.Quote]* _thisptr
 
-Notice that in our header files we use 'Quote' to refer the the C++ class (in file _quote.pxd)
- and to the python class (in file quote.pxd). To avoid 
-confusion we use the following convention:
+Notice that in our header files we use 'Quote' to refer the the C++
+class (in file _quote.pxd) and to the python class (in file
+quote.pxd). To avoid confusion we use the following convention:
 
- * the C++ class is always refered to as ''_qt.Quote''. 
- * the python class is always referd to as ''Quote''
+* the C++ class is always refered to as ``_qt.Quote``.
+* the python class is always refered to as ``Quote``
 
-The cython wrapper class holds a reference to the QL c++ class. As we do not
+The cython wrapper class holds a reference to the QL C++ class. As we do not
 want to do any memory handling on the Python side, we always wrap the C++
 object into a boost shared pointer that is deallocated properly when
 deallocation the Cython extension.
@@ -104,55 +106,53 @@ deallocation the Cython extension.
 Implementation of the python class
 ----------------------------------
 
-The third file contains the implementation of the cython wrapper class. As an illustration, the implementation of the ''SingleQuote'' python class 
-is reproduced below::
+The third file contains the implementation of the cython wrapper
+class. As an illustration, the implementation of the ``SingleQuote``
+python class is reproduced below::
 
-    cdef class SimpleQuote(Quote):
+   cdef class SimpleQuote(Quote):
+      def __init__(self, double value=0.0):
+         self._thisptr = new shared_ptr[_qt.Quote](new _qt.SimpleQuote(value))
 
-	def __init__(self, double value=0.0):
-	    self._thisptr = new shared_ptr[_qt.Quote](new _qt.SimpleQuote(value))
-
-    def __dealloc__(self):
-        if self._thisptr is not NULL:
+      def __dealloc__(self):
+         if self._thisptr is not NULL:
             del self._thisptr # properly deallocates the shared_ptr and
-                              # probably the target object if not referenced 
+                              # probably the target object if not referenced
 
-	def __str__(self):
-	    return 'Simple Quote: %f' % self._thisptr.get().value()
+      def __str__(self):
+         return 'Simple Quote: %f' % self._thisptr.get().value()
 
-	property value:
-	    def __get__(self):
+      property value:
+         def __get__(self):
             if self._thisptr.get().isValid():
-                return self._thisptr.get().value()
+               return self._thisptr.get().value()
             else:
-                return None
+               return None
 
-	    def __set__(self, double value):
+        def __set__(self, double value):
             (<_qt.SimpleQuote*>self._thisptr.get()).setValue(value)
 
-The ''__init__'' method invokes the c++ constructor, which returns a boost shared pointer.
+The ``__init__`` method invokes the C++ constructor, which returns a boost shared pointer.
 
-Properties are used to give a more pythonic flavor to the wrapping. 
-In python, we get the value of the ''SimpleQuote'' with the syntax
-''spot.value'' rather than ''spot.value()'', had we exposed 
+Properties are used to give a more pythonic flavor to the wrapping.
+In python, we get the value of the ``SimpleQuote`` with the syntax
+``spot.value`` rather than ``spot.value()``, had we exposed
 directly the C++ accessor.
-    
-Remember from the previous section that ''_thisptr'' is a shared pointer 
-on a ''Quote'', which is a virtual class. The ''setValue'' 
-method is defined in the ''SimpleQuote'' concrete class, 
-and the shared pointer must therefore be cast 
-into a ''SimpleQuote'' shared pointer in order to invoke ''setValue()''.
-    
+
+Remember from the previous section that ``_thisptr`` is a shared pointer
+on a ``Quote``, which is a virtual class. The ``setValue``
+method is defined in the ``SimpleQuote`` concrete class,
+and the shared pointer must therefore be cast
+into a ``SimpleQuote`` shared pointer in order to invoke ``setValue()``.
+
 Managing C++ references using shared_ptr
 ----------------------------------------
 
 All the Cython extension references should be declared using shared_ptr. The
-__dealloc__ method should always delete the shared_ptr but never the target
+``__dealloc__`` method should always delete the shared_ptr but never the target
 pointer!
 
 Every time a shared_ptr reference is received, never assigns the target pointer
 to a local pointer variables as it might be deallocated. Always use the copy
 constructor of the shared_ptr to get a local copy of it, stack allocated (there
-is no need to use new)
-
-
+is no need to use new).

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -7,7 +7,7 @@ Debugging with gdb
 
 When running into segfault, the easiest way to debug things is to use gdb. Here
 is a example trying to debug a segfault while accessing the implied_quote
-propery of a SwapRateHelper
+property of a SwapRateHelper::
 
     gdb python
     (gdb) run quantlib/test/test_rate_helpers.py

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -60,10 +60,11 @@ The instructions have been tested on Ubuntu 12.04 LTS.
 Prerequisites:
 
 * python 2.7
-* C++ development environment 
+* C++ development environment
 * pandas 0.9
 
 1. Install Boost (taken from a nice post_ by S. Zebardast)
+
 
    a. Download the Boost source package
 
@@ -72,33 +73,32 @@ Prerequisites:
         wget -O boost_1_55_0.tar.gz \
         http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.gz/download
         tar xzvf boost_1_55_0.tar.gz
-
    b. Make sure you have the required libraries
 
       .. code-block:: bash
 
         sudo apt-get update
-        sudo apt-get install build-essential g++ python-dev autotools-dev libicu-dev libbz2-dev 
+        sudo apt-get install build-essential g++ python-dev autotools-dev libicu-dev libbz2-dev
 
-  c. Build and install
+   c. Build and install
 
-     .. code-block:: bash
+      .. code-block:: bash
 
-       cd boost_1_55_0
-       sudo ./bootstrap.sh --prefix=/usr/local
-       sudo ./b2 install
+        cd boost_1_55_0
+        sudo ./bootstrap.sh --prefix=/usr/local
+        sudo ./b2 install
 
-   If /usr/local/lib is not in your path:
+      If /usr/local/lib is not in your path:
 
-   .. code-block:: bash
+      .. code-block:: bash
 
-     sudo sh -c 'echo "/usr/local/lib" >> /etc/ld.so.conf.d/local.conf'
-  
-   and finally:
+        sudo sh -c 'echo "/usr/local/lib" >> /etc/ld.so.conf.d/local.conf'
 
-   .. code-block:: bash
+      and finally:
 
-     sudo ldconfig
+      .. code-block:: bash
+
+        sudo ldconfig
 
 2. Install Quantlib
 
@@ -123,7 +123,7 @@ Prerequisites:
       .. code-block:: bash
 
 		      cd QuantLib-1.5
-		      ./configure --disable-static CXXFLAGS=-O2 --with-boost-include=/usr/local/include --with-boost-lib=/usr/local/lib 
+		      ./configure --disable-static CXXFLAGS=-O2 --with-boost-include=/usr/local/include --with-boost-lib=/usr/local/lib
 
    d. Make and install
 
@@ -173,51 +173,51 @@ Prerequisites:
 1. Install Quantlib
 
    a. Install the latest version of Boost from sourceforge. You can get the
-   binaries of 1.55 for windows 32 or 64bit depending on your target.
-   
+      binaries of 1.55 for windows 32 or 64bit depending on your target.
+
    b. Download Quantlib 1.5 from Quantlib.org and unzip locally
 
    c. Extract the Quantlib folder
 
    d. Open the QuantLib_vc9 solution with Visual Studio
-   
+
    e. Patch ql/settings.py
 
-    In the ql/settings.py file, update the Settings class defintion as
-    following (line 37)::
-    
+      In the ql/settings.py file, update the Settings class defintion as
+      following (line 37)::
+
         class __declspec(dllexport) Settings : public Singleton<Settings> {
 
    f. In the QuantLib project properties
-    
+
     - Change "General" -> "Configuration type" to "Dynamic Library (DLL)"
     - Apply
     - Add the Boost include directory to "C/C++" -> "Additional Include Directories"
     - Apply
-    
+
     Do a first build to get all the object files generated
-    
+
    g. Generate the def file:
-   
+
     In your PyQL clone, got the scripts directory, and edit the main function.
-    Set `input_directory` to the Release directory where your object files are 
+    Set `input_directory` to the Release directory where your object files are
     and change the `output_file` if appropriate (symbol_win32.def is the
     default) ! The def file is platform specific (you can't reuse a 32bit def
     file for a 64bit linker).
-    
+
     This will generate a def file of about 44 Mb with all the needed symbols for
     PyQL compilation.
-    
+
    h. Build the dll with the new def file
-   
-    - Change "Linker" -> "Input" -> "Module definition file" to point to 
+
+    - Change "Linker" -> "Input" -> "Module definition file" to point to
       def file you just generated.
-   
+
      Apply the changes and build the project
-     
+
    i. Copy the QuantLib.dll to a directory which is on the PATH (or just the
       PyQL directory if you're in development mode)
-   
+
 2. Install Cython. While you can install Cython from source, we strongly
    recommend to install Cython via the Canopy Package Manager, another Python
    distribution or via pip_::
@@ -239,12 +239,12 @@ Prerequisites:
         PS C:\dev\pyql> python setup.py install
 
    .. note:: Development mode
-   
+
         If you want to build the library in place and test things, you can do:
-        
+
 
         .. code-block:: bash
-        
+
                 PS C:\dev\pyql> python setup.py build_ext --inplace
                 PS C:\dev\pyql> python -m unittest discover -v
 

--- a/quantlib/cashflow.pyx
+++ b/quantlib/cashflow.pyx
@@ -1,12 +1,10 @@
-"""
- Copyright (C) 2013, Enthought Inc
- Copyright (C) 2013, Patrick Henaff
- Copyright (c) 2012 BG Research LLC
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2013, Enthought Inc
+# Copyright (C) 2013, Patrick Henaff
+# Copyright (c) 2012 BG Research LLC
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 cimport _cashflow as _cf
 cimport quantlib.time._date as _date

--- a/quantlib/currency/_currency.pxd
+++ b/quantlib/currency/_currency.pxd
@@ -1,11 +1,11 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+#
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 include '../types.pxi'
 from libcpp cimport bool

--- a/quantlib/currency/api.py
+++ b/quantlib/currency/api.py
@@ -1,11 +1,11 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+#
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 from .currency_registry import currency_from_name
 from .currency import Currency

--- a/quantlib/currency/currencies.pyx
+++ b/quantlib/currency/currencies.pyx
@@ -1,5 +1,5 @@
-""" Module that contains all the country specific currency implementations.
-
+"""
+Contains all the country specific currency implementations.
 """
 
 cimport _currency as _cu

--- a/quantlib/currency/currency.pxd
+++ b/quantlib/currency/currency.pxd
@@ -1,15 +1,13 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+#
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 cimport _currency
 
 cdef class Currency:
     cdef _currency.Currency *_thisptr
-
-

--- a/quantlib/currency/currency.pyx
+++ b/quantlib/currency/currency.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 cimport _currency as _cu
 

--- a/quantlib/index.pyx
+++ b/quantlib/index.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2013, Enthought Inc
- Copyright (C) 2013, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2013, Enthought Inc
+# Copyright (C) 2013, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include 'types.pxi'
 

--- a/quantlib/instruments/bonds.pyx
+++ b/quantlib/instruments/bonds.pyx
@@ -146,11 +146,11 @@ cdef class Bond(Instrument):
 cdef class FixedRateBond(Bond):
     """ Fixed rate bond.
     Support:
-        - simple annual compounding coupon rates
+    - simple annual compounding coupon rates
 
     Unsupported: (needs interfacing)
-        - simple annual compounding coupon rates with internal schedule calculation
-        - generic compounding and frequency InterestRate coupons
+    - simple annual compounding coupon rates with internal schedule calculation
+    - generic compounding and frequency InterestRate coupons
     """
 
     def __init__(self, int settlement_days, double face_amount,

--- a/quantlib/instruments/bonds.pyx
+++ b/quantlib/instruments/bonds.pyx
@@ -94,7 +94,7 @@ cdef class Bond(Instrument):
         return date_from_qldate(settlement_date)
 
     property clean_price:
-        """ Bond clena price. """
+        """ Bond clean price. """
         def __get__(self):
             if self._has_pricing_engine:
                 return get_bond(self).cleanPrice()

--- a/quantlib/instruments/bonds.pyx
+++ b/quantlib/instruments/bonds.pyx
@@ -94,7 +94,7 @@ cdef class Bond(Instrument):
         return date_from_qldate(settlement_date)
 
     property clean_price:
-        """ Bond clean price. """
+        """ Bond clena price. """
         def __get__(self):
             if self._has_pricing_engine:
                 return get_bond(self).cleanPrice()
@@ -146,11 +146,11 @@ cdef class Bond(Instrument):
 cdef class FixedRateBond(Bond):
     """ Fixed rate bond.
     Support:
-    - simple annual compounding coupon rates
+        - simple annual compounding coupon rates
 
     Unsupported: (needs interfacing)
-    - simple annual compounding coupon rates with internal schedule calculation
-    - generic compounding and frequency InterestRate coupons
+        - simple annual compounding coupon rates with internal schedule calculation
+        - generic compounding and frequency InterestRate coupons
     """
 
     def __init__(self, int settlement_days, double face_amount,

--- a/quantlib/instruments/bonds.pyx
+++ b/quantlib/instruments/bonds.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include '../types.pxi'
 

--- a/quantlib/instruments/credit_default_swap.pyx
+++ b/quantlib/instruments/credit_default_swap.pyx
@@ -1,11 +1,10 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 include '../types.pxi'
 

--- a/quantlib/instruments/credit_default_swap.pyx
+++ b/quantlib/instruments/credit_default_swap.pyx
@@ -39,15 +39,43 @@ cdef _cds.CreditDefaultSwap* _get_cds(CreditDefaultSwap cds):
 cdef class CreditDefaultSwap(Instrument):
     """Credit default swap
 
-        .. note::
+        Parameters
+        ----------
+        side : int or {BUYER, SELLER}
+           Whether the protection is bought or sold.
+        notional : float
+            Notional value
+        spread  : float
+            Running spread in fractional units.
+        schedule : :class:`~quantlib.time.schedule.Schedule`
+            Coupon schedule.
+        paymentConvention : int
+            Business-day convention for
+            payment-date adjustment.
+        dayCounter : :class:`~quantlib.time.daycounter.DayCounter`
+            Day-count convention for accrual.
+        settlesAccrual : bool, optional
+            Whether or not the accrued coupon is
+            due in the event of a default.
+        paysAtDefaultTime : bool, optional
+            If set to True, any payments
+            triggered by a default event are
+            due at default time. If set to
+            False, they are due at the end of
+            the accrual period.
+        protectionStart : :class:`~quantlib.time.date.Date`, optional
+            The first date where a default
+            event will trigger the contract.
 
-            This instrument currently assumes that the issuer did
-              not default until today's date.
+        Notes
+        -----
+        This instrument currently assumes that the issuer did
+        not default until today's date.
 
-        ..warning::
+        .. warning::
 
-            if Settings.includeReferenceDateCashFlows()
-            is set to <tt>true</tt>, payments occurring at the
+            if ``Settings.include_reference_date_cashflows``
+            is set to ``True``, payments occurring at the
             settlement date of the swap might be included in the
             NPV and therefore affect the fair-spread
             calculation. This might not be what you want.
@@ -62,22 +90,6 @@ cdef class CreditDefaultSwap(Instrument):
                  Date protection_start=Date()):
         """ CDS quoted as running-spread only
 
-            @param side  Whether the protection is bought or sold.
-            @param notional  Notional value
-            @param spread  Running spread in fractional units.
-            @param schedule  Coupon schedule.
-            @param paymentConvention  Business-day convention for
-                                      payment-date adjustment.
-            @param dayCounter  Day-count convention for accrual.
-            @param settlesAccrual  Whether or not the accrued coupon is
-                                   due in the event of a default.
-            @param paysAtDefaultTime  If set to true, any payments
-                                      triggered by a default event are
-                                      due at default time. If set to
-                                      false, they are due at the end of
-                                      the accrual period.
-            @param protectionStart  The first date where a default
-                                    event will trigger the contract.
         """
 
         self._thisptr = new shared_ptr[_instrument.Instrument](
@@ -101,10 +113,10 @@ cdef class CreditDefaultSwap(Instrument):
         """ Returns the running spread that, given the quoted recovery
             rate, will make the running-only CDS have an NPV of 0.
 
-            .. note::
-
-                This calculation does not take any upfront into account, even if
-                one was given.
+            Notes
+            -----
+            This calculation does not take any upfront into account, even if
+            one was given.
         """
         def __get__(self):
             return _get_cds(self).fairSpread()

--- a/quantlib/interest_rate.pyx
+++ b/quantlib/interest_rate.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include 'types.pxi'
 

--- a/quantlib/models/equity/bates_model.pyx
+++ b/quantlib/models/equity/bates_model.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include '../../types.pxi'
 

--- a/quantlib/pricingengines/swaption.pyx
+++ b/quantlib/pricingengines/swaption.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2015, Enthought Inc
- Copyright (C) 2015, Patrick Hénaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2015, Enthought Inc
+# Copyright (C) 2015, Patrick Hénaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 from cython.operator cimport dereference as deref
 

--- a/quantlib/processes/heston_process.pyx
+++ b/quantlib/processes/heston_process.pyx
@@ -20,13 +20,14 @@ cdef public enum Discretization:
         QUADRATICEXPONENTIALMARTINGALE = _hp.QuadraticExponentialMartingale
 
 cdef class HestonProcess:
-    r"""Heston process: a diffusion process with mean-reverting stochastic variance.
+    r"""
+    Heston process: a diffusion process with mean-reverting stochastic variance.
 
     .. math::
 
-      dS_t =& (r-d) S_t dt + \sqrt{V_t} S_t dW^s_t \\
-      dV_t =& \kappa (\theta - V_t) dt + \varepsilon \sqrt{V_t} dW^\upsilon_t \nonumber \\
-      dW^s_t dW^\upsilon_t =& \rho dt \nonumber
+        dS_t =& (r-d) S_t dt + \sqrt{V_t} S_t dW^s_t \\
+        dV_t =& \kappa (\theta - V_t) dt + \varepsilon \sqrt{V_t} dW^\upsilon_t \\
+        dW^s_t dW^\upsilon_t =& \rho dt
 
     """
 

--- a/quantlib/processes/heston_process.pyx
+++ b/quantlib/processes/heston_process.pyx
@@ -20,12 +20,13 @@ cdef public enum Discretization:
         QUADRATICEXPONENTIALMARTINGALE = _hp.QuadraticExponentialMartingale
 
 cdef class HestonProcess:
-    """Heston process: a diffusion process with mean-reverting stochastic variance.
+    r"""Heston process: a diffusion process with mean-reverting stochastic variance.
 
     .. math::
-    dS_t &=& (r-d) S_t dt + \sqrt{V_t} S_t dW^s_t \\
-    dV_t &=& \kappa (\theta - V_t) dt + \varepsilon \sqrt{V_t} dW^\\upsilon_t \nonumber \\
-    dW^s_t dW^\\upsilon_t &=& \rho dt \nonumber
+
+      dS_t =& (r-d) S_t dt + \sqrt{V_t} S_t dW^s_t \\
+      dV_t =& \kappa (\theta - V_t) dt + \varepsilon \sqrt{V_t} dW^\upsilon_t \nonumber \\
+      dW^s_t dW^\upsilon_t =& \rho dt \nonumber
 
     """
 

--- a/quantlib/termstructures/credit/default_probability_helpers.pyx
+++ b/quantlib/termstructures/credit/default_probability_helpers.pyx
@@ -1,11 +1,11 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+#
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 from cython.operator cimport dereference as deref
 

--- a/quantlib/termstructures/credit/default_probability_helpers.pyx
+++ b/quantlib/termstructures/credit/default_probability_helpers.pyx
@@ -26,13 +26,21 @@ from quantlib.termstructures.yields.yield_term_structure cimport YieldTermStruct
 
 cdef class CdsHelper:
     """Base default-probability bootstrap helper
-        @param tenor  CDS tenor.
-        @param frequency  Coupon frequency.
-        @param settlementDays  The number of days from today's date
-                               to the start of the protection period.
-        @param paymentConvention The payment convention applied to
-                                 coupons schedules, settlement dates
-                                 and protection period calculations.
+
+    Parameters
+    ----------
+    tenor :  :class:`~quantlib.time.date.Period`
+        CDS tenor.
+    frequency :  Frequency
+        Coupon frequency.
+    settlementDays : Integer
+        The number of days from today's date
+        to the start of the protection period.
+    paymentConvention : BusinessDayConvention
+        The payment convention applied to
+        coupons schedules, settlement dates
+        and protection period calculations.
+
     """
 
     @property

--- a/quantlib/termstructures/credit/default_probability_helpers.pyx
+++ b/quantlib/termstructures/credit/default_probability_helpers.pyx
@@ -49,7 +49,32 @@ cdef class CdsHelper:
         return date_from_qldate(d)
 
 cdef class SpreadCdsHelper(CdsHelper):
-    """Spread-quoted CDS hazard rate bootstrap helper. """
+    """Spread-quoted CDS hazard rate bootstrap helper.
+
+    Parameters
+    ----------
+    running_spread : float
+        Running spread of the CDS.
+    tenor :  :class:`~quantlib.time.date.Period`
+        CDS tenor.
+    settlementDays : int
+        The number of days from today's date
+        to the start of the protection period.
+    calendar: :class:`~quantlib.time.calendar.Calendar`
+    frequency :  Frequency
+        Coupon frequency.
+    payment_convention : int
+        The payment convention applied to
+        coupons schedules, settlement dates
+        and protection period calculations.
+    date_generation_rule : int
+    daycounter : :class:`~quantlib.time.daycounter.DayCounter`
+    recovery_rate : float
+    discount_curve : :class:`~quantlib.termstructures.yields.yield_term_structure.YieldTermStructure`
+    settles_accrual : bool, optional
+    pays_at_default_time : bool, optional
+
+    """
 
     def __init__(self, double running_spread, Period tenor, int settlement_days,
                  Calendar calendar, int frequency,

--- a/quantlib/termstructures/credit/interpolated_hazardrate_curve.pyx
+++ b/quantlib/termstructures/credit/interpolated_hazardrate_curve.pyx
@@ -16,13 +16,11 @@ from quantlib.time.calendar cimport Calendar
 cimport quantlib.time._calendar as _calendar
 
 cdef class InterpolatedHazardRateCurve(DefaultProbabilityTermStructure):
-    def __init__(self, Interpolator interpolator, list dates, vector[Rate] hazard_rates,
-                 DayCounter day_counter not None, Calendar cal = None):
-        """DefaultProbabilityTermStructure based on interpolation of hazard rates
+    """DefaultProbabilityTermStructure based on interpolation of hazard rates
 
         Parameters
         ----------
-        interpolator :
+        interpolator : int {Linear, LogLinear, BackwardFlat}
             can be one of Linear, LogLinear, BackwardFlat
         dates : :obj:`list` of :class:`~quantlib.time.date.Date`
             list of dates
@@ -31,7 +29,9 @@ cdef class InterpolatedHazardRateCurve(DefaultProbabilityTermStructure):
         day_counter: :class:`~quantlib.time.daycounter.DayCounter`
         cal: :class:`~quantlib.time.calendar.Calendar`
 
-        """
+    """
+    def __init__(self, Interpolator interpolator, list dates, vector[Rate] hazard_rates,
+                 DayCounter day_counter not None, Calendar cal = None):
         # convert the list of PyQL dates into a vector of QL dates
         cdef vector[_date.Date] _dates
         for date in dates:
@@ -104,7 +104,7 @@ cdef class InterpolatedHazardRateCurve(DefaultProbabilityTermStructure):
 
     @property
     def data(self):
-        """"list of curve data"""
+        """list of curve data"""
         if self._trait == Linear:
             return (<_ihc.InterpolatedHazardRateCurve[_ihc.Linear]*>
                     self._thisptr.get()).data()

--- a/quantlib/termstructures/inflation_term_structure.pyx
+++ b/quantlib/termstructures/inflation_term_structure.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2016, Enthought Inc
- Copyright (C) 2016, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2016, Enthought Inc
+# Copyright (C) 2016, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include '../types.pxi'
 

--- a/quantlib/termstructures/yields/flat_forward.pyx
+++ b/quantlib/termstructures/yields/flat_forward.pyx
@@ -1,11 +1,10 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
 
 include '../../types.pxi'
 from cython.operator cimport dereference as deref

--- a/quantlib/termstructures/yields/piecewise_yield_curve.pyx
+++ b/quantlib/termstructures/yields/piecewise_yield_curve.pyx
@@ -21,21 +21,22 @@ VALID_INTERPOLATORS = ['loglinear', 'linear', 'spline']
 cdef class PiecewiseYieldCurve(YieldTermStructure):
     """A piecewise yield curve.
 
-    Parameters:
-    -----------
-    trait: str
+    Parameters
+    ----------
+    trait : str
         the kind of curve. Must be either 'discount', 'forward' or 'zero'
-    interpolator: str
+    interpolator : str
         the kind of interpolator. Must be either 'loglinear', 'linear' or
         'spline'
-    settlement_date: quantlib.time.date.Date
+    settlement_date : quantlib.time.date.Date
         The settlement date
-    helpers: [RateHelper's]
-        a list of rate helper to used to create the curve
-    day_counter: quantlib.time.day_counter.DayCounter
+    helpers : list of quantlib.termstructures.rate_helpers.RateHelper
+        a list of rate helpers used to create the curve
+    day_counter : quantlib.time.day_counter.DayCounter
         the day counter used by this curve
-    tolerance: double (default 1e-12)
+    tolerance : double (default 1e-12)
         the tolerance
+
     """
 
     def __init__(self, str trait, str interpolator, Date settlement_date,
@@ -79,4 +80,3 @@ cdef class PiecewiseYieldCurve(YieldTermStructure):
                 )
             )
         )
-

--- a/quantlib/termstructures/yields/rate_helpers.pyx
+++ b/quantlib/termstructures/yields/rate_helpers.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 include '../../types.pxi'
 

--- a/quantlib/termstructures/yields/yield_term_structure.pyx
+++ b/quantlib/termstructures/yields/yield_term_structure.pyx
@@ -107,16 +107,17 @@ cdef class YieldTermStructure:
 
         Parameters
         ----------
-        date: :py:class`~quantlib.time.date.Date'
+        date : :class:`~quantlib.time.date.Date`
             The date used to calcule the zero-yield rate.
-        day_counter: :py:class`~quantlib.time.daycounter.DayCounter'
+        day_counter : :class:`~quantlib.time.daycounter.DayCounter`
             The day counter used to compute the time.
-        compounding: int
+        compounding : int
             The compounding as defined in quantlib.compounding
-        frequency: int
+        frequency : int
             A frequency as defined in quantlib.time.date
-        extraplolate: bool, optional
+        extraplolate : bool, optional
             Default to False
+
         """
         self._raise_if_empty()
 
@@ -150,16 +151,17 @@ cdef class YieldTermStructure:
 
         Parameters
         ----------
-        d1, d2: :py:class`~quantlib.time.date.Date'
+        d1, d2 : :class:`~quantlib.time.date.Date`
             The start and end dates used to calcule the forward rate.
-        day_counter: :py:class`~quantlib.time.daycounter.DayCounter'
+        day_counter : :class:`~quantlib.time.daycounter.DayCounter`
             The day counter used to compute the time.
-        compounding: int
+        compounding : int
             The compounding as defined in quantlib.compounding
-        frequency: int
-            A frequency as defined in quantlib.time.date
-        extraplolate: bool, optional
+        frequency : int
+            A frequency as defined in :mod:`quantlib.time.date`
+        extrapolate : bool, optional
             Default to False
+
         """
         self._raise_if_empty()
 
@@ -241,5 +243,3 @@ cdef class YieldTermStructure:
             cdef _yts.YieldTermStructure* term_structure = self._get_term_structure()
             cdef int days = term_structure.settlementDays()
             return days
-
-        

--- a/quantlib/time/calendar.pyx
+++ b/quantlib/time/calendar.pyx
@@ -1,11 +1,9 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 # Cython standard cimports
 from cython.operator cimport dereference as deref, preincrement as inc

--- a/quantlib/time/date.pyx
+++ b/quantlib/time/date.pyx
@@ -306,7 +306,9 @@ def days(p):
         return _period.days(deref((<Period>p)._thisptr.get()))
 
 cdef class Date:
-    """ This class provides methods to inspect dates as well as methods and
+    """ Date class
+
+    It provides methods to inspect dates as well as methods and
     operators which implement a limited date algebra (increasing and decreasing
     dates, and calculating their difference).
 

--- a/quantlib/time/date.pyx
+++ b/quantlib/time/date.pyx
@@ -102,10 +102,10 @@ def str_to_frequency(str name):
     return _STR_FREQ_DICT[name]
 
 cdef public enum TimeUnit:
-    Days   = _period.Days
-    Weeks  = _period.Weeks
-    Months = _period.Months
-    Years  = _period.Years
+    Days   = _period.Days #: Days = 0
+    Weeks  = _period.Weeks #: Weeks = 1
+    Months = _period.Months #: Months = 2
+    Years  = _period.Years #: Years = 3
 
 _TU_DICT = {'D': Days, 'W': Weeks, 'M': Months, 'Y': Years}
 _STR_TU_DICT = {v:k for k, v in _TU_DICT.items()}

--- a/quantlib/time/daycounters/thirty360.pyx
+++ b/quantlib/time/daycounters/thirty360.pyx
@@ -42,7 +42,10 @@ Italian convention: starting dates or ending dates that
 occur on February and are grater than 27 become equal to 30
 for computational sake.
 
-Valid names for 30/360 daycounts are:\n{}
+Valid names for 30/360 daycounts are:
+
+* {}
+
 
 """
 
@@ -52,7 +55,7 @@ cdef class Thirty360(DayCounter):
         '30/360({})'.format(convention ) for convention in CONVENTIONS
     ]
     __doc__ =  DOC_TEMPLATE.format(
-        '\n'.join(_valid_names)
+        '\n* '.join(_valid_names)
     )
 
     def __cinit__(self, convention=BONDBASIS):

--- a/quantlib/types.pxi
+++ b/quantlib/types.pxi
@@ -1,11 +1,11 @@
-"""
- Copyright (C) 2011, Enthought Inc
- Copyright (C) 2011, Patrick Henaff
-
- This program is distributed in the hope that it will be useful, but WITHOUT
- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE.  See the license for more details.
-"""
+#
+# Copyright (C) 2011, Enthought Inc
+# Copyright (C) 2011, Patrick Henaff
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the license for more details.
+#
 
 # from ql/types.hpp
 ctypedef int Integer


### PR DESCRIPTION
I tried to clean up the docs. It's still a work in progress, but it should be quite a few improvements already.

Of note:
- I have turned on numpydoc style for the docstrings. Some classes where already kind of documented like that, so I think it makes sense.
- I have moved some of the copyright header to comments instead of docstring, otherwise they get picked up by sphinx as a documentation for the module.

I'm not sure how this all work with readthedocs, hopefully it will be getting picked up automatically. We could probably add a link to the docs on the readme as well.