### PR TITLE
Build with QuantLib 1.8 and Cython 0.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ before_install:
  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
  - sudo apt-get update
  - sudo apt-get install -qq python-numpy python-six
+ - sudo add-apt-repository -y ppa:edd/misc
+ - sudo apt-get update
+ - sudo apt-get install libquantlib0-dev
  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main universe"
  - sudo apt-get update
  - sudo apt-get install libquantlib0-dev
- - pip install -r requirements.txt --use-mirrors
+ - pip install -r requirements.txt
 install:
     make build
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cython >= 0.23
+cython >= 0.24
 pandas >= 0.16.2
 tabulate
 enum34


### PR DESCRIPTION
Minor modifications to travis.yml and requirements.txt to build with QuantLib 1.8 and Cython 0.24