### PR TITLE
Fast period parsing

### DIFF
--- a/quantlib/test/test_date.py
+++ b/quantlib/test/test_date.py
@@ -236,6 +236,13 @@ class TestQuantLibPeriod(unittest.TestCase):
         self.assertEqual(Months, period.units)
         self.assertEqual(OtherFrequency, period.frequency)
 
+    def test_creation_with_string(self):
+        period1 = Period("3M")
+        period2 = Period("3m")
+        period3 = Period(3, Months)
+        self.assertEqual(period1, period2)
+        self.assertEqual(period1, period3)
+
     def test_adding_period_to_date(self):
 
         date1 = Date(1, May, 2011)

--- a/quantlib/time/_period.pxd
+++ b/quantlib/time/_period.pxd
@@ -1,5 +1,6 @@
 include '../types.pxi'
 from libcpp cimport bool
+from libcpp.string cimport string
 
 cdef extern from 'ql/time/frequency.hpp' namespace "QuantLib":
     cdef enum Frequency:
@@ -29,6 +30,7 @@ cdef extern from 'ql/time/period.hpp' namespace "QuantLib":
     cdef cppclass Period:
 
         Period()
+        Period(Period&)
         Period (Integer n, TimeUnit units)
         Period (Frequency f)
 
@@ -57,3 +59,6 @@ cdef extern from 'ql/time/period.hpp' namespace "QuantLib":
     Real months(const Period& p) except +
     Real weeks(const Period& p) except +
     Real days(const Period& p) except +
+
+cdef extern from 'ql/utilities/dataparsers.hpp' namespace "QuantLib::PeriodParser":
+    Period parse(string& str) except +

--- a/quantlib/time/date.pyx
+++ b/quantlib/time/date.pyx
@@ -13,13 +13,11 @@ from _date cimport (
 )
 from _period cimport (
     Period as QlPeriod, mult_op, add_op, sub_op, eq_op, neq_op,
-    g_op, geq_op, l_op, leq_op
+    g_op, geq_op, l_op, leq_op, parse
     )
 
 # Python imports
 import datetime
-import re
-
 import six
 
 cdef public enum Month:
@@ -111,11 +109,6 @@ _TU_DICT = {'D': Days, 'W': Weeks, 'M': Months, 'Y': Years}
 _STR_TU_DICT = {v:k for k, v in _TU_DICT.items()}
 
 
-tenor_re = re.compile("([0-9]+)([DWMY]{1,1})")
-def parse(tenor):
-    mo = tenor_re.match(tenor)
-    return (mo.group(1), mo.group(2))
-
 cdef class Period:
     ''' Class providing a Period (length + time unit) class and implements a
     limited algebra.
@@ -126,14 +119,7 @@ cdef class Period:
         if len(args) == 1:
             tenor = args[0]
             if(isinstance(tenor, six.string_types)):
-                try:
-                    t, u = parse(tenor)
-                except:
-                    raise ValueError("Parse Error: could not parse period %s" \
-                                     % tenor)
-                self._thisptr = \
-                new shared_ptr[QlPeriod](new QlPeriod(<Integer> int(t),
-                                         <TimeUnit> _TU_DICT[u]))
+                self._thisptr = new shared_ptr[QlPeriod](new QlPeriod(parse(tenor.encode('utf-8'))))
             else:
                 self._thisptr = \
                 new shared_ptr[QlPeriod](new QlPeriod(<_period.Frequency>args[0]))


### PR DESCRIPTION
This uses QuantLib provided function. Also parsing is looser: it will take "3m" and "3M" for instance, before only capital letters would be parsed.