### PR TITLE
Correct syntax for Period in test cases

### DIFF
--- a/quantlib/test/test_heston_model.py
+++ b/quantlib/test/test_heston_model.py
@@ -242,7 +242,7 @@ class HestonModelTestCase(unittest.TestCase):
 
         daycounter = ActualActual()
 
-        exercise_date = settlement_date + 6 * Months
+        exercise_date = settlement_date + Period(6, Months)
 
         payoff = PlainVanillaPayoff(Put, 30)
 
@@ -299,7 +299,7 @@ class HestonModelTestCase(unittest.TestCase):
 
         daycounter = ActualActual()
 
-        exercise_date = settlement_date + 6 * Months
+        exercise_date = settlement_date + Period(6, Months)
 
         payoff = PlainVanillaPayoff(Put, 1290)
         exercise = EuropeanExercise(exercise_date)


### PR DESCRIPTION
A few test cases have syntax like 6*Months to mean 6 months, in fact it evaluates to 12 days. Thanks to @thrasibule for pointing that out.