### PR TITLE
Filter lto flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,9 @@ class pyql_build_ext(build_ext):
             self.compiler.compiler_so.remove("-Wstrict-prototypes")
         except (AttributeError, ValueError):
             pass
+        lto_flags=["-flto", "-flto-partition=none", "-fuse-linker-plugin",
+                   "-ffat-lto-objects"]
+        self.compiler.compiler_so = [f for f in self.compiler.compiler_so if f not in lto_flags]
         build_ext.build_extensions(self)
 
     def run(self):


### PR DESCRIPTION
If cpython is built with lto enabled (--with-lto at configure time),
these flags are also added to the compilation of cython generated
files, which breaks the singleton pattern (the Settings object is not
unique anymore).