### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/business_dates.rst
+++ b/docs/source/business_dates.rst
@@ -209,7 +209,7 @@ The schedule is initialized by the Schedule class::
 The arguments represent the following
 
  * effective_date, termination_date: start/end of the schedule
- * tenor: a Period object reprensenting the frequency of the schedule 
+ * tenor: a Period object representing the frequency of the schedule 
    (e.g. every 3 months)
  * termination_date_convention: allows to specify a special business day 
    convention for the final date.

--- a/docs/source/cython_wrapper.rst
+++ b/docs/source/cython_wrapper.rst
@@ -76,7 +76,7 @@ The syntax is almost identical to the corresponding C++ header file. The
 types used in declaring arguments are defined in ``types.pxi``.
 
 The clause 'except +' signals that the method may throw an exception. It
-is indispensible to append this clause to every declaration. Without it, an
+is indispensable to append this clause to every declaration. Without it, an
 exception thrown in QL will terminate the python process.
 
 Declaration of the python class
@@ -95,8 +95,8 @@ Notice that in our header files we use 'Quote' to refer the the C++
 class (in file _quote.pxd) and to the python class (in file
 quote.pxd). To avoid confusion we use the following convention:
 
-* the C++ class is always refered to as ``_qt.Quote``.
-* the python class is always refered to as ``Quote``
+* the C++ class is always referred to as ``_qt.Quote``.
+* the python class is always referred to as ``Quote``
 
 The cython wrapper class holds a reference to the QL C++ class. As we do not
 want to do any memory handling on the Python side, we always wrap the C++

--- a/docs/source/market.rst
+++ b/docs/source/market.rst
@@ -3,7 +3,7 @@ Market
 
 PyQL is primarily a wrapper around QuantLib, and strictly follows the QuantLib class structure. A casual look at the PyQL test
 suite will convince the user that using QuantLib, or its PyQL wrapper, requires a pretty detailed understanding of its class
-structure. The number of market convention parameters that need to be supplied in order to perform the simplest calculation can be overwelming.  
+structure. The number of market convention parameters that need to be supplied in order to perform the simplest calculation can be overwhelming.  
 
 In an attempt to bring some order and logic to this profusion of market conventions, PyQL introduces the notion of Market.
 A Market is the virtual place where financial assets are traded. It defines all the conventions needed to quote prices, measure yield, compute yield curves from market quotes, etc. Examples of these virtual market places are:

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -7,7 +7,7 @@ QuantLib.
 Getting started
 ---------------
 
-In order to use the notebokks, you need to install:
+In order to use the notebooks, you need to install:
 
 * Ipython 0.13
 * pylab

--- a/examples/option_valuation.py
+++ b/examples/option_valuation.py
@@ -181,7 +181,7 @@ def dividendOption():
     strike = 190
     option_type = Call 
 
-    # Here, as an implementation exemple, we make the test with borth american and european exercise
+    # Here, as an implementation example, we make the test with borth american and european exercise
     europeanExercise = EuropeanExercise(maturity)
     # The emericanExercise need also the settlement date, as his right to exerce the buy or call start at the settlement date!
     #americanExercise = AmericanExercise(settlementDate, maturity)
@@ -196,7 +196,7 @@ def dividendOption():
 
 
     # ++++++++++++++++++ Description of the discrete dividends
-    # INPUT You have to determine the frequece and rates of the discrete dividend. Here is a sollution, but she's not the only one.
+    # INPUT You have to determine the frequence and rates of the discrete dividend. Here is a sollution, but she's not the only one.
     # Last know dividend:
     dividend			= 0.75 #//0.75
     next_dividend_date	= Date(10,Feb,2012)

--- a/examples/scripts/OptionQuotes.py
+++ b/examples/scripts/OptionQuotes.py
@@ -56,7 +56,7 @@ from __future__ import print_function
 # $$
 # \sigma(K) = \frac{\sigma_b(K)+\sigma_a(K)}{2}
 # $$
-# 3. Let $F$ be the forward price, the corresponding mid-market implied volatility is computed by linear interpolation between the two quuotes braketing $F$.
+# 3. Let $F$ be the forward price, the corresponding mid-market implied volatility is computed by linear interpolation between the two quotes bracketing $F$.
 # 
 # The forward ATM volatility is the average of the volatilities computed on calls and puts.
 # 

--- a/quantlib/mlab/term_structure.py
+++ b/quantlib/mlab/term_structure.py
@@ -29,7 +29,7 @@ def zbt_libor_yield(instruments, yields, pricing_date,
 
     Args:
 
-    insruments:    list of instruments, of the form Libor?M for Libor rates
+    instruments:    list of instruments, of the form Libor?M for Libor rates
                    and Swap?Y for swap rates
     yields:        market rates
     pricing_date:  the date where market data is observed. Settlement

--- a/quantlib/test/test_date.py
+++ b/quantlib/test/test_date.py
@@ -101,7 +101,7 @@ class TestQuantLibDate(unittest.TestCase):
         expected_date = Date(22, Nov, 1998)
         self.assertTrue(expected_date == date1)
 
-        # substraction
+        # subtraction
         date1 = Date(19, Nov, 1998)
         date3 = date1 - 5
         expected_date = Date(14, Nov, 1998)
@@ -276,7 +276,7 @@ class TestQuantLibPeriod(unittest.TestCase):
         expected_date = Date(1, Mar, 2012)
         self.assertTrue(expected_date == date2)
 
-    def test_period_substraction(self):
+    def test_period_subtraction(self):
 
         period1 = Period(11, Months)
         period2 = Period(EveryFourthMonth)
@@ -324,7 +324,7 @@ class TestQuantLibPeriod(unittest.TestCase):
             period3 = Period(2, Weeks)
             period += period3  # does not support different units
 
-    def test_inplace_substraction(self):
+    def test_inplace_subtraction(self):
 
         period = Period(Semiannual)
 

--- a/quantlib/test/test_mlab.py
+++ b/quantlib/test/test_mlab.py
@@ -54,7 +54,7 @@ class MLabTestCase(unittest.TestCase):
 
     def test_blsprice(self):
         """
-        from maltab documentation of blsprice
+        from matlab documentation of blsprice
         """
         p = blsprice(spot=585, strike=600, risk_free_rate=.05,
                      time=1 / 4., volatility=.25,

--- a/quantlib/test/test_process.py
+++ b/quantlib/test/test_process.py
@@ -71,7 +71,7 @@ class ProcessTestCase(unittest.TestCase):
         me = BatesDoubleExpModel(ph)
         self.assertIsNotNone(me)
 
-        # speficy the arguments
+        # specify the arguments
         me = BatesDoubleExpModel(ph, Lambda=0.234, nuUp=0.43, nuDown=0.54, p=.6)
         self.assertIsNotNone(me)
 

--- a/quantlib/test/test_zero_coupon.py
+++ b/quantlib/test/test_zero_coupon.py
@@ -101,7 +101,7 @@ class ZeroCouponTestCase(unittest.TestCase):
                                  ts_day_counter,
                                  tolerance)
 
-        # max_date raises an exception without extrapolaiton...
+        # max_date raises an exception without extrapolation...
         self.assertFalse(ts.extrapolation)
         with self.assertRaises(RuntimeError) as ctx:
             ts.discount(ts.max_date + 1)

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ def collect_extensions():
     of Extension.
 
     Th function combines static Extension declaration and calls to cythonize
-    to build the list of extenions.
+    to build the list of extensions.
     """
 
     kwargs = {


### PR DESCRIPTION
There are small typos in:
- docs/source/business_dates.rst
- docs/source/cython_wrapper.rst
- docs/source/market.rst
- docs/source/notebooks.rst
- examples/option_valuation.py
- examples/scripts/OptionQuotes.py
- quantlib/mlab/term_structure.py
- quantlib/test/test_date.py
- quantlib/test/test_mlab.py
- quantlib/test/test_process.py
- quantlib/test/test_zero_coupon.py
- setup.py

Fixes:
- Should read `referred` rather than `refered`.
- Should read `subtraction` rather than `substraction`.
- Should read `specify` rather than `speficy`.
- Should read `representing` rather than `reprensenting`.
- Should read `quotes` rather than `quuotes`.
- Should read `overwhelming` rather than `overwelming`.
- Should read `notebooks` rather than `notebokks`.
- Should read `matlab` rather than `maltab`.
- Should read `instruments` rather than `insruments`.
- Should read `indispensable` rather than `indispensible`.
- Should read `frequence` rather than `frequece`.
- Should read `extrapolation` rather than `extrapolaiton`.
- Should read `extensions` rather than `extenions`.
- Should read `example` rather than `exemple`.
- Should read `bracketing` rather than `braketing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md